### PR TITLE
Change back to using npm for gbxremote

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"bignum": ">=0.6.1",
 		"async": ">=0.2.9",
 		"compressjs": ">=1.0.0",
-		"gbxremote": "git://github.com/sonicsnes/node-gbxremote.git",
+		"gbxremote": "~0.1.4",
 		"request": ">=2.22.0"
 	}
 }


### PR DESCRIPTION
`gbxremote` has changed the parsing of data from the server using [barse](https://github.com/juliangruber/barse), so the patch should no longer be needed. You can send me a pull-request next time you optimize my code. Would be very appreciated.
