### PR TITLE
On error return options within the callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ class Gamedig {
             if(callback.length === 2) {
                 promise
                     .then((state) => callback(null,state))
-                    .catch((error) => callback(error));
+                    .catch((error) => callback(error, options));
             } else if (callback.length === 1) {
                 promise
                     .then((state) => callback(state))


### PR DESCRIPTION
Gives back more information when promise errors out.

Currently using this in a series of server information queues, without giving the options back or more information it's hard to tell what server isn't responding. I figure this is a simple addition to the callback that otherwise wouldn't pass in any information about the query before.