### PR TITLE
Add givenPortOnly user option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ this query port may work instead. (defaults to protocol default port)
  will cause many queries to take longer even if the server is online. (default 2000)
 * **attemptTimeout**: number - Milliseconds allowed for an entire query attempt. This timeout is not commonly hit,
  as the socketTimeout typically fires first. (default 10000)
+* **givenPortOnly**: boolean - Only attempt to query server on given port. (default false)
 * **debug**: boolean - Enables massive amounts of debug logging to stdout. (default false)
 
 ### Return Value

--- a/bin/gamedig.js
+++ b/bin/gamedig.js
@@ -4,13 +4,15 @@ const Minimist = require('minimist'),
     Gamedig = require('..');
 
 const argv = Minimist(process.argv.slice(2), {
-    boolean: ['pretty','debug']
+    boolean: ['pretty','debug','givenPortOnly']
 });
 
 const debug = argv.debug;
 delete argv.debug;
 const pretty = !!argv.pretty || debug;
 delete argv.pretty;
+const givenPortOnly = argv.givenPortOnly;
+delete argv.givenPortOnly;
 
 const options = {};
 for(const key of Object.keys(argv)) {
@@ -33,6 +35,9 @@ if (argv._.length >= 1) {
 }
 if (debug) {
     options.debug = true;
+}
+if (givenPortOnly) {
+    options.givenPortOnly = true;
 }
 
 Gamedig.query(options)

--- a/lib/QueryRunner.js
+++ b/lib/QueryRunner.js
@@ -30,7 +30,7 @@ class QueryRunner {
         const attempts = [];
 
         if (userOptions.port) {
-            if (gameQueryPortOffset) {
+            if (gameQueryPortOffset && !userOptions.givenPortOnly) {
                 attempts.push({
                     ...defaultOptions,
                     ...gameOptions,
@@ -38,7 +38,7 @@ class QueryRunner {
                     port: userOptions.port + gameQueryPortOffset
                 });
             }
-            if (userOptions.port === gameOptions.port && gameQueryPort) {
+            if (userOptions.port === gameOptions.port && gameQueryPort && !userOptions.givenPortOnly) {
                 attempts.push({
                     ...defaultOptions,
                     ...gameOptions,


### PR DESCRIPTION
Allows user to disable gamedig's default behavior of adding query attempts using the default query port(-offset).

Adding query attempts for a game's default port or the game port plus a default offset is great for ease of use. However, if you are using gamedig at "scale" and you already know the correct query port these attempts will slow you significantly, especially if maxAttempts is set to anything higher than 1.

An advanced option to disable this default behavior allows anyone who figured the query ports out beforehand to reduce the total query duration and reduce unnecessary CPU load. Also, since a gameQueryPortOffset-based attempt will currently be added regardless of the given port, the resulting attempt might have a port higher than 65535.

- Updated QueryRunner + gamedig binary
- Updated README
- Tested locally via cli/bin and a project using gamedig

Test using 643 Battlefield 4 servers for which the query port is known (128 queries concurrently, 2 attempts, 1640 socket timeout). Small change, big effect:
`givenPortOnly: false` (default)
```
8:45:40 PM worker.1 |  BF4 : Updating gamedig states
8:45:52 PM worker.1 |  BF4 : gamedig update stats { fulfilled: 604, rejected: 39 }
```
`givenPortOnly: true`
```
8:43:00 PM worker.1 |  BF4 : Updating gamedig states
8:43:04 PM worker.1 |  BF4 : gamedig update stats { fulfilled: 604, rejected: 39 }
```
12 seconds vs 4 seconds.