### PR TITLE
Fix teamOffByOne condition for Battlefield 1942

### DIFF
--- a/protocols/gamespy1.js
+++ b/protocols/gamespy1.js
@@ -46,7 +46,7 @@ class Gamespy1 extends Core {
         if ('maxplayers' in data) state.maxplayers = parseInt(data.maxplayers);
         if ('hostport' in data) state.gamePort = parseInt(data.hostport);
 
-        const teamOffByOne = data.gameid === 'bf1942';
+        const teamOffByOne = data.gamename === 'bfield1942';
         const playersById = {};
         const teamNamesById = {};
         for (const ident of Object.keys(data)) {


### PR DESCRIPTION
I was wondering why the `team` property is often empty for one team on a Battlefield 1942 server. Turns out: The current condition for `teamOffByOne` only matches for servers hosting the main game/mod because `gameid` contains the current mod for 1942. Servers hosting `desertcombat` or other mods don't match the condition.

Current condition:
```javascript
const teamOffByOne = data.gameid === 'bf1942';
```

Server info:
```json
{
  "name": "Badewiese [Public DC Server]",
  "map": "kursk",
  "password": false,
  "raw": {
    "gamename": "bfield1942",
    "gamever": "v1.612",
    "averagefps": 0,
    "content_check": 0,
    "dedicated": 2,
    "gameid": "desertcombat"
}
```

So, check via `gamename` instead.

```javascript
const teamOffByOne = data.gamename === 'bfield1942';
```

Test server: `78.46.52.115:23000`