### PR TITLE
Allow direct control of IP family to be returned by DNS lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ this query port may work instead. (defaults to protocol default port)
 * **attemptTimeout**: number - Milliseconds allowed for an entire query attempt. This timeout is not commonly hit,
  as the socketTimeout typically fires first. (default 10000)
 * **givenPortOnly**: boolean - Only attempt to query server on given port. (default false)
+* **ipFamily**: number - IP family/version returned when looking up hostnames via DNS, can be 0 (IPv4 and IPv6), 4 (IPv4 only) or 6 (IPv6 only). (default 0)
 * **debug**: boolean - Enables massive amounts of debug logging to stdout. (default false)
 * **requestRules**: boolean - Valve games only. Additional 'rules' may be fetched into the `raw` field. (default false)
 

--- a/bin/gamedig.js
+++ b/bin/gamedig.js
@@ -5,7 +5,7 @@ const Minimist = require('minimist'),
 
 const argv = Minimist(process.argv.slice(2), {
     boolean: ['pretty','debug','givenPortOnly','requestRules'],
-    string: ['guildId','listenUdpPort']
+    string: ['guildId','listenUdpPort','ipFamily']
 });
 
 const debug = argv.debug;

--- a/lib/DnsResolver.js
+++ b/lib/DnsResolver.js
@@ -20,10 +20,11 @@ class DnsResolver {
     /**
      * Response port will only be present if srv record was involved.
      * @param {string} host
+     * @param {number} ipFamily
      * @param {string=} srvRecordPrefix
      * @returns {Promise<{address:string, port:number=}>}
      */
-    async resolve(host, srvRecordPrefix) {
+    async resolve(host, ipFamily, srvRecordPrefix) {
         this.logger.debug("DNS Lookup: " + host);
 
         if(this.isIp(host)) {
@@ -52,7 +53,7 @@ class DnsResolver {
                     }
                     return {
                         port: srvPort,
-                        ...await this.resolve(srvHost, srvRecordPrefix)
+                        ...await this.resolve(srvHost, ipFamily, srvRecordPrefix)
                     };
                 }
                 this.logger.debug("No SRV Record");
@@ -62,7 +63,7 @@ class DnsResolver {
         }
 
         this.logger.debug("Standard Resolve: " + host);
-        const dnsResult = await dnsLookupAsync(host);
+        const dnsResult = await dnsLookupAsync(host, ipFamily);
         // For some reason, this sometimes returns a string address rather than an object.
         // I haven't been able to reproduce, but it's been reported on the issue tracker.
         let address;

--- a/lib/QueryRunner.js
+++ b/lib/QueryRunner.js
@@ -5,7 +5,8 @@ const GameResolver = require('./GameResolver'),
 const defaultOptions = {
     socketTimeout: 2000,
     attemptTimeout: 10000,
-    maxAttempts: 1
+    maxAttempts: 1,
+    ipFamily: 0
 };
 
 class QueryRunner {
@@ -19,7 +20,7 @@ class QueryRunner {
     async run(userOptions) {
         for (const key of Object.keys(userOptions)) {
             const value = userOptions[key];
-            if (['port'].includes(key)) {
+            if (['port', 'ipFamily'].includes(key)) {
                 userOptions[key] = parseInt(value);
             }
         }

--- a/protocols/core.js
+++ b/protocols/core.js
@@ -69,7 +69,7 @@ class Core extends EventEmitter {
     async runOnce() {
         const options = this.options;
         if (('host' in options) && !('address' in options)) {
-            const resolved = await this.dnsResolver.resolve(options.host, this.srvRecord);
+            const resolved = await this.dnsResolver.resolve(options.host, options.ipFamily, this.srvRecord);
             options.address = resolved.address;
             if (resolved.port) options.port = resolved.port;
         }


### PR DESCRIPTION
As mentioned in #306, query may currently fail if the DNS lookup happens to return an IPv6 `AAAA` record instead of an existing IPv4 `A` record. In order to avoid such issues, these changes enables users to directly control which type of record/ip family they accept.

Tested locally with the server mentioned in #306.