### PR TITLE
Fixed Minecraft resolver only reporting 0 ping. #310

### DIFF
--- a/protocols/minecraft.js
+++ b/protocols/minecraft.js
@@ -76,20 +76,20 @@ class Minecraft extends Core {
             } catch(e) {}
             if (vanillaState.maxplayers) state.maxplayers = vanillaState.maxplayers;
             if (vanillaState.players.length) state.players = vanillaState.players;
-            if (vanillaState.ping) state.ping = vanillaState.ping;
+            if (vanillaState.ping) this.registerRtt(vanillaState.ping);
         }
         if (gamespyState) {
             if (gamespyState.name) state.name = gamespyState.name;
             if (gamespyState.maxplayers) state.maxplayers = gamespyState.maxplayers;
             if (gamespyState.players.length) state.players = gamespyState.players;
             else if (gamespyState.raw.numplayers) state.players.setNum(parseInt(gamespyState.raw.numplayers));
-            if (gamespyState.ping) state.ping = gamespyState.ping;
+            if (gamespyState.ping) this.registerRtt(gamespyState.ping);
         }
         if (bedrockState) {
             if (bedrockState.name) state.name = bedrockState.name;
             if (bedrockState.maxplayers) state.maxplayers = bedrockState.maxplayers;
             if (bedrockState.map) state.map = bedrockState.map;
-            if (bedrockState.ping) state.ping = bedrockState.ping;
+            if (bedrockState.ping) this.registerRtt(bedrockState.ping);
         }
         // remove dupe spaces from name
         state.name = state.name.replace(/\s+/g, ' ');


### PR DESCRIPTION
Minecraft resolver now uses registerRtt rather than setting state.ping. This prevents the ping value being overwritten with 0 as shortestRTT is never set.

This fixes the bug reported in #310, which is a regression of #233.