### PR TITLE
Add support for Onset

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Games List
 | `nmrih`    | No More Room in Hell (2011) | [Valve Protocol](#valve)
 | `nolf2`    | No One Lives Forever 2: A Spy in H.A.R.M.'s Way (2002)
 | `nucleardawn` | Nuclear Dawn (2011) | [Valve Protocol](#valve)
+| `onset`    | Onset (2019) | [Valve Protocol](#valve)
 | `openarena` | OpenArena (2005)
 | `openttd`  | OpenTTD (2004)
 | `operationflashpoint`<br>`flashpoint` | Operation Flashpoint: Cold War Crisis (2001)

--- a/games.txt
+++ b/games.txt
@@ -184,6 +184,7 @@ nitrofamily|Nitro Family (2004)|gamespy1|port_query=25601
 nolf|The Operative: No One Lives Forever (2000)|gamespy1|port_query=27888
 nolf2|No One Lives Forever 2: A Spy in H.A.R.M.'s Way (2002)|gamespy1|port_query=27890
 nucleardawn|Nuclear Dawn (2011)|valve|port=27015
+onset|Onset (2019)|valve|port=7777,port_query_offset=-1
 openarena|OpenArena (2005)|quake3|port_query=27960
 openttd|OpenTTD (2004)|openttd|port=3979
 painkiller|Painkiller|ase|port=3455,port_query_offset=123


### PR DESCRIPTION
Another one which turned out to work with the Valve protocol. Game port is 7777, query port is 7776. Tested with below servers.

IP:Port|Game|Version
---------|-----------|----------
193.34.69.12:27260|Onset|1.0.0.0
45.137.151.202:7776|Onset|1.0.0.0
141.95.18.200:7776|Onset|1.0.0.0
141.95.18.200:6776|Onset|1.0.0.0
141.95.18.200:7736|Onset|1.0.0.0
141.95.18.200:7756|Onset|1.0.0.0
141.95.18.200:7746|Onset|1.0.0.0
216.105.171.138:7776|Onset|1.0.0.0