### PR TITLE
Add support for Don't Starve Together

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Games List
 | `dinodday` | Dino D-Day (2011) | [Valve Protocol](#valve)
 | `dirttrackracing2` | Dirt Track Racing 2 (2002)
 | `discord`  | Discord | [Notes](#discord)
+| `dst`      | Don't Starve Together (2016) | [Valve Protocol](#valve)
 | `doom3`    | Doom 3 (2004)
 | `dota2`    | Dota 2 (2013) | [Valve Protocol](#valve)
 | `drakan`   | Drakan: Order of the Flame (1999)

--- a/games.txt
+++ b/games.txt
@@ -98,6 +98,7 @@ doi|Day of Infamy (2017)|valve|port=27015
 doom3|Doom 3 (2004)|doom3|port=27666
 dota2|Dota 2 (2013)|valve|port=27015
 drakan|Drakan: Order of the Flame (1999)|gamespy1|port=27045,port_query_offset=1
+dst|Don't Starve Together (2016)|valve|port=10999,port_query=27016
 empyrion|Empyrion - Galactic Survival (2015)|valve|port=30000,port_query_offset=1
 etqw|Enemy Territory: Quake Wars (2007)|doom3|port=3074,port_query=27733
 fear|F.E.A.R. (2005)|gamespy2|port_query=27888


### PR DESCRIPTION
Yet another Valve protocol game. Only about 25% of the servers in the list responded to my query, not sure why the others did not. Game port is 10999, query is on 27016.

IP:Port|Game|Version
---------|--------|----------
139.162.199.57:12346|Don't Starve Together|438711
46.163.117.215:12348|Don't Starve Together|446029
46.163.117.215:12346|Don't Starve Together|446029
84.201.138.232:12348|Don't Starve Together|382128
84.201.138.232:12346|Don't Starve Together|382128
115.227.0.242:12346|Don't Starve Together|451587
106.53.236.70:27017|Don't Starve Together|446681
118.25.70.57:12348|Don't Starve Together|428872
106.54.76.143:12348|Don't Starve Together|438182
106.54.76.143:12346|Don't Starve Together|438182
106.53.236.70:27016|Don't Starve Together|446681
45.224.128.32:12348|Don't Starve Together|427361
45.224.128.32:12346|Don't Starve Together|427361