### PR TITLE
Add support for Chivalry: Medieval Warfare

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Games List
 | `codwaw`   | Call of Duty: World at War (2008)
 | `callofjuarez` | Call of Juarez (2006)
 | `chaser`   | Chaser (2003)
+| `chivalry` | Chivalry: Medieval Warfare (2012) | [Valve Protocol](#valve)
 | `chrome`   | Chrome (2003)
 | `codenameeagle` | Codename Eagle (2000)
 | `cacrenegade` | Command and Conquer: Renegade (2002)

--- a/games.txt
+++ b/games.txt
@@ -55,6 +55,7 @@ codmw3|Call of Duty: Modern Warfare 3 (2011)|valve|port_query_offset=2
 
 callofjuarez|Call of Juarez (2006)|ase|port_query=26000
 chaser|Chaser (2003)|ase|port=3000,port_query_offset=123
+chivalry|Chivalry: Medieval Warfare (2012)|valve|port=7777,port_query_offset=2
 chrome|Chrome (2003)|ase|port=27015,port_query_offset=123
 codenameeagle|Codename Eagle (2000)|gamespy1|port_query=4711
 commandos3|Commandos 3: Destination Berlin (2003)|gamespy1|port_query=6500


### PR DESCRIPTION
As pointed out in #235, Chivalry: Medieval Warfare uses the Valve protocol. Current default game port is 7777, default query port is 7779.

IP:Port|Game|Version
---------|--------|----------
173.244.207.46:21015|Chivalry: Medieval Warfare|1.0.0.1
185.107.96.212:7822|Chivalry: Medieval Warfare|1.0.0.1
51.89.155.137:21019|Chivalry: Medieval Warfare|1.0.0.1
51.91.105.87:21027|Chivalry: Medieval Warfare|1.0.0.1
54.38.29.203:21015|Chivalry: Medieval Warfare|1.0.0.1
51.91.105.87:21019|Chivalry: Medieval Warfare|1.0.0.1
135.181.61.161:7810|Chivalry: Medieval Warfare|1.0.0.1
185.209.177.153:21015|Chivalry: Medieval Warfare|1.0.0.1
199.127.62.226:5556|Chivalry: Medieval Warfare|1.0.0.1
74.91.115.164:27015|Chivalry: Medieval Warfare|1.0.0.1