### PR TITLE
Add support for Rising World

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Games List
 | `ricochet` | Ricochet | [Valve Protocol](#valve)
 | `riseofnations` | Rise of Nations
 | `rs2`      | Rising Storm 2: Vietnam | [Valve Protocol](#valve)
+| `risingworld` | Rising World (2014) | [Valve Protocol](#valve)
 | `ror2`     | Risk of Rain 2 (2020) | [Valve Protocol](#valve)
 | `rune`     | Rune
 | `rust`     | Rust | [Valve Protocol](#valve)

--- a/games.txt
+++ b/games.txt
@@ -226,6 +226,7 @@ rtcw|Return to Castle Wolfenstein|quake3|port_query=27960
 rfactor|rFactor|rfactor|port=34397,port_query_offset=-100
 ricochet|Ricochet|valve|port=27015
 riseofnations|Rise of Nations|gamespy1|port_query=6501
+risingworld|Rising World (2014)|valve|port=4255
 ror2|Risk of Rain 2 (2020)|valve|port=27015,port_query_offset=1
 rs2|Rising Storm 2: Vietnam|valve|port=27015
 rune|Rune|gamespy1|port=7777,port_query_offset=1


### PR DESCRIPTION
Valve protocol. Game and query port is 4255 by default, as pointed out in #229.

IP:Port|Game|Version
---------|--------|----------
62.104.13.181:4255|Rising World|201911051
62.104.164.59:22809|Rising World (New Version)|202211111
134.255.222.201:23010|Rising World|201911051
195.4.106.15:4255|Rising World|201911051
5.147.199.113:4255|Rising World|201911051
185.250.250.104:4255|Rising World|201911051
51.195.5.215:4254|Rising World (New Version)|202211111
54.37.206.245:4254|Rising World (New Version)|202211111
185.239.237.104:4300|Rising World|201911051
185.239.238.125:4354|Rising World (New Version)|202211111