### PR TITLE
Add support for Avorion

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Games List
 | `armagetron` | Armagetron Advanced (2001)
 | `assettocorsa` | Assetto Corsa (2014)
 | `atlas`    | Atlas (2018) | [Valve Protocol](#valve)
+| `avorion`  | Avorion (2020) | [Valve Protocol](#valve)
 | `baldursgate` | Baldur's Gate (1998)
 | `barotrauma` | Barotrauma (2019) | [Valve Protocol](#valve)
 | `bat1944`  | Battalion 1944 (2018) | [Valve Protocol](#valve)

--- a/games.txt
+++ b/games.txt
@@ -8,6 +8,7 @@ alienswarm|Alien Swarm (2010)|valve|port=27015
 arkse|Ark: Survival Evolved (2017)|valve|port=7777,port_query=27015
 assettocorsa|Assetto Corsa (2014)|assettocorsa|port=9610
 atlas|Atlas (2018)|valve|port=5761,port_query_offset=51800
+avorion|Avorion (2020)|valve|port=27000,port_query_offset=20
 avp2|Aliens versus Predator 2 (2001)|gamespy1|port=27888
 avp2010|Aliens vs. Predator (2010)|valve|port=27015
 


### PR DESCRIPTION
Valve protocol, mentioned in #223. Game port 27000, query port 27020 (many providers keep the +20 pattern).

Port:IP|Game|Version
---------|--------|----------
92.224.23.151:27020|Avorion|2.3.0.40132
62.104.13.158:27020|Avorion|2.3.0.40132
62.104.66.220:21220|Avorion|2.3.0.40132
62.104.164.82:22620|Avorion|2.3.0.40132
134.255.222.225:21620|Avorion|2.3.0.40132
134.255.222.248:22320|Avorion|2.3.0.40132
195.82.159.223:26808|Avorion|2.3.0.40132
5.83.172.225:59808|Avorion|2.3.0.40132
46.251.235.171:23008|Avorion|2.3.0.40132
5.83.168.252:11508|Avorion|2.3.0.40132