### PR TITLE
Add support for Black Mesa

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Games List
 | `bfh`      | Battlefield Hardline (2015)
 | `bfv`      | Battlefield Vietnam (2004)
 | `bfbc2`    | Battlefield: Bad Company 2 (2010)
+| `blackmesa` | Black Mesa (2020) | [Valve Protocol](#valve)
 | `breach`   | Breach (2011) | [Valve Protocol](#valve)
 | `breed`    | Breed (2004)
 | `brink`    | Brink (2011) | [Valve Protocol](#valve)

--- a/games.txt
+++ b/games.txt
@@ -39,6 +39,7 @@ bf3|Battlefield 3 (2011)|battlefield|port=25200,port_query_offset=22000
 bf4|Battlefield 4 (2013)|battlefield|port=25200,port_query_offset=22000
 bfh|Battlefield Hardline (2015)|battlefield|port=25200,port_query_offset=22000
 
+blackmesa|Black Mesa (2020)|valve|port=27015
 breach|Breach (2011)|valve|port=27016
 breed|Breed (2004)|gamespy2|port=7649
 brink|Brink (2011)|valve|port_query_offset=1


### PR DESCRIPTION
Valve protocol. Game/query port is 27015.

IP:Port|Game|Version
---------|--------|----------
34.73.85.163:27015|Black Mesa|100001
34.73.205.169:27015|Black Mesa|100001
104.196.44.133:27015|Black Mesa|100001
34.75.188.20:27015|Black Mesa|100001
142.4.210.168:27026|Black Mesa|100001
144.217.10.50:27037|Black Mesa|100001
186.19.99.1:27023|Black Mesa|100001
43.247.158.122:27019|Black Mesa|100001
45.77.246.174:27015|Black Mesa|100001
45.32.115.189:27015|Black Mesa|100001