### PR TITLE
Add support for BrainBread 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Games List
 | `bfv`      | Battlefield Vietnam (2004)
 | `bfbc2`    | Battlefield: Bad Company 2 (2010)
 | `blackmesa` | Black Mesa (2020) | [Valve Protocol](#valve)
+| `brainbread2` | BrainBread 2 (2022) | [Valve Protocol](#valve)
 | `breach`   | Breach (2011) | [Valve Protocol](#valve)
 | `breed`    | Breed (2004)
 | `brink`    | Brink (2011) | [Valve Protocol](#valve)

--- a/games.txt
+++ b/games.txt
@@ -42,6 +42,7 @@ bf4|Battlefield 4 (2013)|battlefield|port=25200,port_query_offset=22000
 bfh|Battlefield Hardline (2015)|battlefield|port=25200,port_query_offset=22000
 
 blackmesa|Black Mesa (2020)|valve|port=27015
+brainbread2|BrainBread 2 (2022)|valve|port=27015
 breach|Breach (2011)|valve|port=27016
 breed|Breed (2004)|gamespy2|port=7649
 brink|Brink (2011)|valve|port_query_offset=1


### PR DESCRIPTION
Valve protocol. Listens for both game and query on port 27015.

IP:Port|Game|Version
---------|--------|----------
135.125.140.182:40115|BrainBread 2|1.0.4.4
178.63.16.211:27115|BrainBread 2|1.0.4.4
176.9.10.34:27310|BrainBread 2|1.0.4.4
176.9.10.34:27415|BrainBread 2|1.0.4.4
109.147.165.130:27015|BrainBread 2|1.0.4.4
185.132.42.12:27056|BrainBread 2|1.0.4.4
31.186.250.26:27015|BrainBread 2|1.0.4.4
222.187.222.120:44444|BrainBread 2|1.0.4.4
73.35.73.153:27097|BrainBread 2|1.0.4.4
199.127.62.79:27117|BrainBread 2|1.0.4.4