### PR TITLE
Add support for Ballistic Overkill

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Games List
 | `assettocorsa` | Assetto Corsa (2014)
 | `atlas`    | Atlas (2018) | [Valve Protocol](#valve)
 | `baldursgate` | Baldur's Gate (1998)
+| `ballisticoverkill` | Ballistic Overkill (2017) | [Valve Protocol](#valve)
 | `barotrauma` | Barotrauma (2019) | [Valve Protocol](#valve)
 | `bat1944`  | Battalion 1944 (2018) | [Valve Protocol](#valve)
 | `bf1942`   | Battlefield 1942 (2002)

--- a/games.txt
+++ b/games.txt
@@ -27,6 +27,7 @@ arma3|ARMA 3 (2013)|valve|port=2302,port_query_offset=1
 
 armagetron|Armagetron Advanced (2001)|armagetron|port=4534
 baldursgate|Baldur's Gate (1998)|gamespy1|port=6073,port_query=1470
+ballisticoverkill|Ballistic Overkill (2017)|valve|port=27015,port_query_offset=1
 barotrauma|Barotrauma (2019)|valve|port=27015,port_query_offset=1
 bat1944|Battalion 1944 (2018)|valve|port=7777,port_query_offset=3
 


### PR DESCRIPTION
Valve protocol. Default game port is 27015, query port is 27016.

IP:Port|Game|Version
---------|--------|----------
178.254.22.169:27016|Ballistic Overkill|1.5.6.0.1
51.195.235.155:27022|Ballistic Overkill|1.5.6.0.1
51.195.235.155:27016|Ballistic Overkill|1.5.6.0.1
15.204.204.143:27016|Ballistic Overkill|1.5.6.0.1
173.198.254.86:27016|Ballistic Overkill|1.5.6.0.1