### PR TITLE
Replace compressjs by seek-bzip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 ### To Be Released...
+* Replace `compressjs` dependency by `seek-bzip` to solve some possible import issues.
 * Sons Of The Forest - Added support
 * Red Dead Redemption 2 - RedM (2018) - Added support
 * Creativerse (2017) - Added support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
     "name": "gamedig",
-    "version": "4.0.6",
+    "version": "4.0.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "gamedig",
-            "version": "4.0.6",
+            "version": "4.0.7",
             "license": "MIT",
             "dependencies": {
                 "cheerio": "^1.0.0-rc.10",
-                "compressjs": "^1.0.2",
                 "gbxremote": "^0.2.1",
                 "got": "^12.1.0",
                 "iconv-lite": "^0.6.3",
                 "long": "^5.2.0",
                 "minimist": "^1.2.6",
                 "punycode": "^2.1.1",
+                "seek-bzip": "^2.0.0",
                 "varint": "^6.0.0"
             },
             "bin": {
@@ -71,14 +71,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.13.tgz",
             "integrity": "sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA==",
             "dev": true
-        },
-        "node_modules/amdefine": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-            "engines": {
-                "node": ">=0.4.2"
-            }
         },
         "node_modules/any-promise": {
             "version": "1.3.0",
@@ -156,29 +148,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
-            }
-        },
-        "node_modules/commander": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-            "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-            "dependencies": {
-                "graceful-readlink": ">= 1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.6.x"
-            }
-        },
-        "node_modules/compressjs": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/compressjs/-/compressjs-1.0.3.tgz",
-            "integrity": "sha1-ldt03VuQOM+AvKMhqw7eJxtJWbY=",
-            "dependencies": {
-                "amdefine": "~1.0.0",
-                "commander": "~2.8.1"
-            },
-            "bin": {
-                "compressjs": "bin/compressjs"
             }
         },
         "node_modules/core-util-is": {
@@ -367,11 +336,6 @@
             "funding": {
                 "url": "https://github.com/sindresorhus/got?sponsor=1"
             }
-        },
-        "node_modules/graceful-readlink": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
         },
         "node_modules/htmlparser2": {
             "version": "6.1.0",
@@ -586,6 +550,26 @@
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
+        "node_modules/seek-bzip": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-2.0.0.tgz",
+            "integrity": "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==",
+            "dependencies": {
+                "commander": "^6.0.0"
+            },
+            "bin": {
+                "seek-bunzip": "bin/seek-bunzip",
+                "seek-table": "bin/seek-bzip-table"
+            }
+        },
+        "node_modules/seek-bzip/node_modules/commander": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/string_decoder": {
             "version": "0.10.31",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -698,11 +682,6 @@
             "integrity": "sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA==",
             "dev": true
         },
-        "amdefine": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-        },
         "any-promise": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -764,23 +743,6 @@
                 "domelementtype": "^2.2.0",
                 "domhandler": "^4.2.0",
                 "domutils": "^2.7.0"
-            }
-        },
-        "commander": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-            "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-            "requires": {
-                "graceful-readlink": ">= 1.0.0"
-            }
-        },
-        "compressjs": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/compressjs/-/compressjs-1.0.3.tgz",
-            "integrity": "sha1-ldt03VuQOM+AvKMhqw7eJxtJWbY=",
-            "requires": {
-                "amdefine": "~1.0.0",
-                "commander": "~2.8.1"
             }
         },
         "core-util-is": {
@@ -907,11 +869,6 @@
                 "p-cancelable": "^3.0.0",
                 "responselike": "^3.0.0"
             }
-        },
-        "graceful-readlink": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
         },
         "htmlparser2": {
             "version": "6.1.0",
@@ -1073,6 +1030,21 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        },
+        "seek-bzip": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-2.0.0.tgz",
+            "integrity": "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==",
+            "requires": {
+                "commander": "^6.0.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+                    "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+                }
+            }
         },
         "string_decoder": {
             "version": "0.10.31",

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
     },
     "dependencies": {
         "cheerio": "^1.0.0-rc.10",
-        "compressjs": "^1.0.2",
         "gbxremote": "^0.2.1",
         "got": "^12.1.0",
         "iconv-lite": "^0.6.3",
         "long": "^5.2.0",
         "minimist": "^1.2.6",
         "punycode": "^2.1.1",
+        "seek-bzip": "^2.0.0",
         "varint": "^6.0.0"
     },
     "bin": {

--- a/protocols/valve.js
+++ b/protocols/valve.js
@@ -1,4 +1,4 @@
-const Bzip2 = require('compressjs').Bzip2;
+const Bzip2 = require('seek-bzip');
 const Core = require('./core');
 const Results = require('../lib/Results');
 const Reader = require('../lib/reader');
@@ -592,7 +592,7 @@ class Valve extends Core {
                     if(bzip) {
                         this.debugLog("BZIP DETECTED - Extracing packet...");
                         try {
-                            assembled = Buffer.from(Bzip2.decompressFile(assembled));
+                            assembled = Bzip2.decode(assembled);
                         } catch(e) {
                             throw new Error('Invalid bzip packet');
                         }


### PR DESCRIPTION
This PR replaces [compressjs](https://www.npmjs.com/package/compressjs) by [seek-bzip](https://www.npmjs.com/package/seek-bzip).

I'm replacing the `compressjs` library as it causes imports problems. The difference between the libraries is that `compressjs` is a library for compression/decompression for a multitude of algorithms, whereas `seek-bzip` does strictly only BZip decoding. 
I'm not really sure about speed but I'd guess its the same.
The usage of `compressjs` was used only in Valve Protocol when decoding compressed packages, unfortunately I couldn't find a server with such compression on, but I compared the output of both versions on some dummy bzip data and they were the same.

Potentially fixes #309, if so it also fixes [homepage#1795](https://github.com/benphelps/homepage/issues/1795) (was fixed in the project with a 'hacky' solution).


