### PR TITLE
feat: add cs2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Empires Mod (2008), Fistful of Frags (2014), alf-Life: Opposing Force (1999),
 Pirates, Vikings, and Knights II (2007), Project Cars (2015), Project Cars 2 (2017),
 The Specialists, Vampire Slayer, Warfork (2018), Wurm Unlimited (2015).
 * Also added support: The Forest (2014), Operation: Harsh Doorstop (2023),
-Insurgency: Modern Infantry Combat (2007)
+Insurgency: Modern Infantry Combat (2007), Counter-Strike 2 (2023).
 * Capitalized 'Unturned' in game.txt
 
 ### 4.1.0

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -75,6 +75,7 @@
 | `cscz`                                | Counter-Strike: Condition Zero (2004)                   | [Valve Protocol](#valve)                    |
 | `csgo`                                | Counter-Strike: Global Offensive (2012)                 | [Notes](#csgo), [Valve Protocol](#valve)    |
 | `css`                                 | Counter-Strike: Source (2004)                           | [Valve Protocol](#valve)                    |
+| `cs2`                                 | Counter-Strike 2 (2023)                                 | [Valve Protocol](#valve)                    |
 | `creativerse`                         | Creativerse (2017)                                      | [Valve Protocol](#valve)                    |
 | `crossracing`                         | Cross Racing Championship Extreme 2005 (2005)           |                                             |
 | `crysis`                              | Crysis (2007)                                           |                                             |
@@ -108,7 +109,7 @@
 | `dystopia`                            | Dystopia (2005)                                         | [Valve Protocol](#valve)                    |
 | `eco`                                 | Eco (2018)                                              |                                             |
 | `empyrion`                            | Empyrion - Galactic Survival (2015)                     | [Valve Protocol](#valve)                    |
-  `empiresmod`                          | Empires Mod (2008)                                      | [Valve Protocol](#valve)                    |
+ `empiresmod`                          | Empires Mod (2008)                                      | [Valve Protocol](#valve)                    |
 | `etqw`                                | Enemy Territory: Quake Wars (2007)                      |                                             |
 | `fear`                                | F.E.A.R. (2005)                                         |                                             |
 | `f1c9902`                             | F1 Challenge '99-'02 (2002)                             |                                             |

--- a/games.txt
+++ b/games.txt
@@ -83,6 +83,7 @@ cs2d|CS2D (2004)|cs2d|port=36963
 cscz|Counter-Strike: Condition Zero (2004)|valve|port=27015
 css|Counter-Strike: Source (2004)|valve|port=27015
 csgo|Counter-Strike: Global Offensive (2012)|valve|port=27015|doc_notes=csgo
+cs2|Counter-Strike 2 (2023)|valve|port=27015
 
 creativerse|Creativerse (2017)|valve|port=26900,port_query_offset=1
 


### PR DESCRIPTION
Closes #356.
This PR does not replace CSGO, as it can still be played, thus it adds a new entry, although it's the same as the old one (the CSGO note needs to be verified.