### PR TITLE
Remove Players::setNum and stabilize field numplayers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ The Specialists, Vampire Slayer, Warfork (2018), Wurm Unlimited (2015).
 * Also added support: The Forest (2014), Operation: Harsh Doorstop (2023),
 Insurgency: Modern Infantry Combat (2007), Counter-Strike 2 (2023).
 * Capitalized 'Unturned' in game.txt
-* Fixed wrong field being parsed for the `maxplayers` on Doom3.
+* Removed the players::setNum method, the library will no longer add empty players as 
+a placeholder in the `players` field.
+* Fixed wrong field being parsed for `maxplayers` on Doom3.
 * Stabilized field `numplayers`.
 
 ### 4.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The Specialists, Vampire Slayer, Warfork (2018), Wurm Unlimited (2015).
 * Also added support: The Forest (2014), Operation: Harsh Doorstop (2023),
 Insurgency: Modern Infantry Combat (2007), Counter-Strike 2 (2023).
 * Capitalized 'Unturned' in game.txt
+* Fixed wrong field being parsed for the `maxplayers` on Doom3.
+* Stabilized field `numplayers`.
 
 ### 4.1.0
 * Replace `compressjs` dependency by `seek-bzip` to solve some possible import issues.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The returned state object will contain the following keys:
 * **name**: string - Server name
 * **map**: string - Current server game map
 * **password**: boolean - If a password is required
+* **numplayers**: number
 * **maxplayers**: number
 * **players**: array of objects
   * **name**: string - If the player's name is unknown, the string will be empty.

--- a/lib/Results.js
+++ b/lib/Results.js
@@ -14,16 +14,6 @@ export class Player {
 }
 
 export class Players extends Array {
-  setNum (num) {
-    // If the server specified some ridiculous number of players (billions), we don't want to
-    // run out of ram allocating these objects.
-    num = Math.min(num, 10000)
-
-    while (this.length < num) {
-      this.push({})
-    }
-  }
-
   push (data) {
     super.push(new Player(data))
   }

--- a/protocols/armagetron.js
+++ b/protocols/armagetron.js
@@ -18,7 +18,7 @@ export default class armagetron extends Core {
     state.gamePort = this.readUInt(reader)
     state.raw.hostname = this.readString(reader)
     state.name = this.stripColorCodes(this.readString(reader))
-    state.raw.numplayers = this.readUInt(reader)
+    state.numplayers = this.readUInt(reader)
     state.raw.versionmin = this.readUInt(reader)
     state.raw.versionmax = this.readUInt(reader)
     state.raw.version = this.readString(reader)

--- a/protocols/ase.js
+++ b/protocols/ase.js
@@ -16,7 +16,7 @@ export default class ase extends Core {
     state.map = this.readString(reader)
     state.raw.version = this.readString(reader)
     state.password = this.readString(reader) === '1'
-    state.raw.numplayers = parseInt(this.readString(reader))
+    state.numplayers = parseInt(this.readString(reader))
     state.maxplayers = parseInt(this.readString(reader))
 
     while (!reader.done()) {

--- a/protocols/assettocorsa.js
+++ b/protocols/assettocorsa.js
@@ -34,5 +34,7 @@ export default class assettocorsa extends Core {
         })
       }
     }
+
+    state.numplayers = carInfo.Cars.length
   }
 }

--- a/protocols/battlefield.js
+++ b/protocols/battlefield.js
@@ -76,8 +76,8 @@ export default class battlefield extends Core {
         for (let i = 0; i < fieldCount; i++) {
           fields.push(data.shift())
         }
-        const numplayers = data.shift()
-        for (let i = 0; i < numplayers; i++) {
+        state.numplayers = data.shift()
+        for (let i = 0; i < state.numplayers; i++) {
           const player = {}
           for (let key of fields) {
             let value = data.shift()
@@ -102,7 +102,6 @@ export default class battlefield extends Core {
           }
           state.players.push(player)
         }
-        state.numplayers = numplayers
       }
     })
   }

--- a/protocols/battlefield.js
+++ b/protocols/battlefield.js
@@ -11,7 +11,7 @@ export default class battlefield extends Core {
       {
         const data = await this.query(socket, ['serverInfo'])
         state.name = data.shift()
-        state.raw.numplayers = parseInt(data.shift())
+        state.numplayers = parseInt(data.shift())
         state.maxplayers = parseInt(data.shift())
         state.raw.gametype = data.shift()
         state.map = data.shift()
@@ -76,8 +76,8 @@ export default class battlefield extends Core {
         for (let i = 0; i < fieldCount; i++) {
           fields.push(data.shift())
         }
-        state.numplayers = data.shift()
-        for (let i = 0; i < state.numplayers; i++) {
+        const numplayers = data.shift()
+        for (let i = 0; i < numplayers; i++) {
           const player = {}
           for (let key of fields) {
             let value = data.shift()

--- a/protocols/battlefield.js
+++ b/protocols/battlefield.js
@@ -102,6 +102,7 @@ export default class battlefield extends Core {
           }
           state.players.push(player)
         }
+        state.numplayers = numplayers
       }
     })
   }

--- a/protocols/buildandshoot.js
+++ b/protocols/buildandshoot.js
@@ -20,7 +20,7 @@ export default class buildandshoot extends Core {
 
     m = body.match(/Current players: (\d+)\/(\d+)/)
     if (m) {
-      state.raw.numplayers = m[1]
+      state.numplayers = parseInt(m[1])
       state.maxplayers = m[2]
     }
 

--- a/protocols/cs2d.js
+++ b/protocols/cs2d.js
@@ -17,7 +17,7 @@ export default class cs2d extends Core {
     state.raw.forceLight = this.readFlag(flags, 7)
     state.name = this.readString(reader)
     state.map = this.readString(reader)
-    state.raw.numplayers = reader.uint(1)
+    state.numplayers = reader.uint(1)
     state.maxplayers = reader.uint(1)
     if (flags & 32) {
       state.raw.gamemode = reader.uint(1)

--- a/protocols/doom3.js
+++ b/protocols/doom3.js
@@ -82,7 +82,7 @@ export default class doom3 extends Core {
     if (state.raw.si_name) state.name = state.raw.si_name
     if (state.raw.si_map) state.map = state.raw.si_map
     if (state.raw.si_maxplayers) state.maxplayers = parseInt(state.raw.si_maxplayers)
-    if (state.raw.si_maxPlayers) state.maxplayers = parseInt(state.raw.si_maxplayers)
+    if (state.raw.si_maxPlayers) state.maxplayers = parseInt(state.raw.si_maxPlayers)
     if (state.raw.si_usepass === '1') state.password = true
     if (state.raw.si_needPass === '1') state.password = true
     if (this.options.port === 27733) state.gamePort = 3074 // etqw has a different query and game port

--- a/protocols/doom3.js
+++ b/protocols/doom3.js
@@ -60,6 +60,7 @@ export default class doom3 extends Core {
     let players;
     [players, reader] = playerResult
 
+    state.numplayers = players.length
     for (const player of players) {
       if (!player.ping || player.typeflag) { state.bots.push(player) } else { state.players.push(player) }
     }

--- a/protocols/eco.js
+++ b/protocols/eco.js
@@ -11,6 +11,7 @@ export default class eco extends Core {
     const serverInfo = request.Info
 
     state.name = serverInfo.Description
+    state.numplayers = serverInfo.OnlinePlayers;
     state.maxplayers = serverInfo.TotalPlayers
     state.password = serverInfo.HasPassword
     state.gamePort = serverInfo.GamePort

--- a/protocols/ffow.js
+++ b/protocols/ffow.js
@@ -24,7 +24,7 @@ export default class ffow extends valve {
     state.raw.description = reader.string()
     state.raw.version = reader.string()
     state.gamePort = reader.uint(2)
-    state.raw.numplayers = reader.uint(1)
+    state.numplayers = reader.uint(1)
     state.maxplayers = reader.uint(1)
     state.raw.listentype = String.fromCharCode(reader.uint(1))
     state.raw.environment = String.fromCharCode(reader.uint(1))

--- a/protocols/gamespy1.js
+++ b/protocols/gamespy1.js
@@ -111,6 +111,8 @@ export default class gamespy1 extends Core {
 
       state.players.push(player)
     }
+
+    state.numplayers = state.players.length
   }
 
   async sendPacket (type) {

--- a/protocols/gamespy2.js
+++ b/protocols/gamespy2.js
@@ -32,6 +32,9 @@ export default class gamespy2 extends Core {
       for (const rawPlayer of this.readFieldData(reader)) {
         state.players.push(rawPlayer)
       }
+
+      if ('numplayers' in state.raw) state.numplayers = parseInt(state.raw.numplayers)
+      else state.numplayers = state.players.length
     }
 
     // Parse teams

--- a/protocols/gamespy3.js
+++ b/protocols/gamespy3.js
@@ -127,6 +127,9 @@ export default class gamespy3 extends Core {
         state.players.push(player)
       }
     }
+
+    if ('numplayers' in state.raw) state.numplayers = parseInt(state.raw.numplayers)
+    else state.numplayers = state.players.length
   }
 
   async sendPacket (type, challenge, payload, assemble) {

--- a/protocols/geneshift.js
+++ b/protocols/geneshift.js
@@ -28,7 +28,7 @@ export default class geneshift extends Core {
     state.raw.country = found[1]
     state.name = found[4]
     state.map = found[5]
-    state.players.setNum(parseInt(found[6]))
+    state.numplayers = parseInt(found[6])
     state.maxplayers = parseInt(found[7])
     // fields[8] is unknown?
     state.raw.rules = found[9]

--- a/protocols/jc2mp.js
+++ b/protocols/jc2mp.js
@@ -12,8 +12,5 @@ export default class jc2mp extends gamespy3 {
 
   async run (state) {
     await super.run(state)
-    if (!state.players.length && parseInt(state.raw.numplayers)) {
-      state.numplayers = parseInt(state.raw.numplayers);
-    }
   }
 }

--- a/protocols/jc2mp.js
+++ b/protocols/jc2mp.js
@@ -13,7 +13,7 @@ export default class jc2mp extends gamespy3 {
   async run (state) {
     await super.run(state)
     if (!state.players.length && parseInt(state.raw.numplayers)) {
-      state.players.setNum(parseInt(state.raw.numplayers))
+      state.numplayers = parseInt(state.raw.numplayers);
     }
   }
 }

--- a/protocols/kspdmp.js
+++ b/protocols/kspdmp.js
@@ -23,5 +23,6 @@ export default class kspdmp extends Core {
         state.players.push({ name })
       }
     }
+    state.numplayers = state.players.length
   }
 }

--- a/protocols/mafia2mp.js
+++ b/protocols/mafia2mp.js
@@ -18,7 +18,7 @@ export default class mafia2mp extends Core {
 
     const reader = this.reader(body)
     state.name = this.readString(reader)
-    state.raw.numplayers = this.readString(reader)
+    state.numplayers = parseInt(this.readString(reader))
     state.maxplayers = parseInt(this.readString(reader))
     state.raw.gamemode = this.readString(reader)
     state.password = !!reader.uint(1)

--- a/protocols/minecraft.js
+++ b/protocols/minecraft.js
@@ -82,7 +82,7 @@ export default class minecraft extends Core {
       if (gamespyState.name) state.name = gamespyState.name
       if (gamespyState.maxplayers) state.maxplayers = gamespyState.maxplayers
       if (gamespyState.players.length) state.players = gamespyState.players
-      else if (gamespyState.raw.numplayers) state.players.setNum(parseInt(gamespyState.raw.numplayers))
+      else if (gamespyState.raw.numplayers) state.numplayers = parseInt(gamespyState.raw.numplayers)
       if (gamespyState.ping) this.registerRtt(gamespyState.ping)
     }
     if (bedrockState) {

--- a/protocols/minecraft.js
+++ b/protocols/minecraft.js
@@ -84,7 +84,7 @@ export default class minecraft extends Core {
       if (gamespyState.numplayers) state.numplayers = gamespyState.numplayers
       if (gamespyState.maxplayers) state.maxplayers = gamespyState.maxplayers
       if (gamespyState.players.length) state.players = gamespyState.players
-      else if (gamespyState.raw.numplayers) state.numplayers = parseInt(gamespyState.raw.numplayers)
+      else if (gamespyState.numplayers) state.numplayers = gamespyState.numplayers
       if (gamespyState.ping) this.registerRtt(gamespyState.ping)
     }
     if (bedrockState) {

--- a/protocols/minecraft.js
+++ b/protocols/minecraft.js
@@ -74,12 +74,14 @@ export default class minecraft extends Core {
         }
         state.name = name
       } catch (e) {}
+      if (vanillaState.numplayers) state.numplayers = vanillaState.numplayers
       if (vanillaState.maxplayers) state.maxplayers = vanillaState.maxplayers
       if (vanillaState.players.length) state.players = vanillaState.players
       if (vanillaState.ping) this.registerRtt(vanillaState.ping)
     }
     if (gamespyState) {
       if (gamespyState.name) state.name = gamespyState.name
+      if (gamespyState.numplayers) state.numplayers = gamespyState.numplayers
       if (gamespyState.maxplayers) state.maxplayers = gamespyState.maxplayers
       if (gamespyState.players.length) state.players = gamespyState.players
       else if (gamespyState.raw.numplayers) state.numplayers = parseInt(gamespyState.raw.numplayers)
@@ -87,6 +89,7 @@ export default class minecraft extends Core {
     }
     if (bedrockState) {
       if (bedrockState.name) state.name = bedrockState.name
+      if (bedrockState.numplayers) state.numplayers = bedrockState.numplayers
       if (bedrockState.maxplayers) state.maxplayers = bedrockState.maxplayers
       if (bedrockState.map) state.map = bedrockState.map
       if (bedrockState.ping) this.registerRtt(bedrockState.ping)

--- a/protocols/minecraftbedrock.js
+++ b/protocols/minecraftbedrock.js
@@ -57,7 +57,7 @@ export default class minecraftbedrock extends Core {
       state.name = split.shift()
       state.raw.protocolVersion = split.shift()
       state.raw.mcVersion = split.shift()
-      state.players.setNum(parseInt(split.shift()))
+      state.numplayers = parseInt(split.shift())
       state.maxplayers = parseInt(split.shift())
       if (split.length) state.raw.serverId = split.shift()
       if (split.length) state.map = split.shift()

--- a/protocols/minecraftvanilla.js
+++ b/protocols/minecraftvanilla.js
@@ -47,6 +47,7 @@ export default class minecraftvanilla extends Core {
 
     state.raw = json
     state.maxplayers = json.players.max
+    state.numplayers = json.players.online
 
     if (json.players.sample) {
       for (const player of json.players.sample) {
@@ -55,13 +56,6 @@ export default class minecraftvanilla extends Core {
           name: player.name
         })
       }
-    }
-
-    // players.sample may not contain all players or no players at all, depending on how many players are online.
-    // Insert a dummy player object for every online player that is not listed in players.sample.
-    // Limit player amount to 10.000 players for performance reasons.
-    for (let i = state.players.length; i < Math.min(json.players.online, 10000); i++) {
-      state.players.push({})
     }
   }
 

--- a/protocols/mumbleping.js
+++ b/protocols/mumbleping.js
@@ -17,7 +17,7 @@ export default class mumbleping extends Core {
     state.raw.versionMinor = reader.uint(1)
     state.raw.versionPatch = reader.uint(1)
     reader.skip(8)
-    state.players.setNum(reader.uint(4))
+    state.numplayers = reader.uint(4)
     state.maxplayers = reader.uint(4)
     state.raw.allowedbandwidth = reader.uint(4)
   }

--- a/protocols/nadeo.js
+++ b/protocols/nadeo.js
@@ -55,6 +55,7 @@ export default class nadeo extends Core {
           name: this.stripColors(player.Name || player.NickName)
         })
       }
+      state.numplayers = state.players.length
     })
   }
 

--- a/protocols/openttd.js
+++ b/protocols/openttd.js
@@ -34,7 +34,7 @@ export default class openttd extends Core {
 
       state.password = !!reader.uint(1)
       state.maxplayers = reader.uint(1)
-      state.players.setNum(reader.uint(1))
+      state.numplayers = reader.uint(1)
       state.raw.numspectators = reader.uint(1)
       state.map = reader.string()
       state.raw.map_width = reader.uint(2)

--- a/protocols/quake2.js
+++ b/protocols/quake2.js
@@ -82,5 +82,7 @@ export default class quake2 extends Core {
     if ('maxclients' in state.raw) state.maxplayers = state.raw.maxclients
     if ('sv_hostname' in state.raw) state.name = state.raw.sv_hostname
     if ('hostname' in state.raw) state.name = state.raw.hostname
+    if ('clients' in state.raw) state.numplayers = state.raw.clients
+    else state.numplayers = state.players.length + state.bots.length
   }
 }

--- a/protocols/rfactor.js
+++ b/protocols/rfactor.js
@@ -22,7 +22,7 @@ export default class rfactor extends Core {
     state.raw.ping = reader.uint(2)
     state.raw.packedFlags = reader.uint(1)
     state.raw.rate = reader.uint(1)
-    state.players.setNum(reader.uint(1))
+    state.numplayers = reader.uint(1)
     state.maxplayers = reader.uint(1)
     state.raw.bots = reader.uint(1)
     state.raw.packedSpecial = reader.uint(1)

--- a/protocols/samp.js
+++ b/protocols/samp.js
@@ -18,7 +18,7 @@ export default class samp extends Core {
         state.raw.version = this.reader(consumed).string()
       }
       state.password = !!reader.uint(1)
-      state.raw.numplayers = reader.uint(2)
+      state.numplayers = reader.uint(2)
       state.maxplayers = reader.uint(2)
       state.name = reader.pascalString(4)
       state.raw.gamemode = reader.pascalString(4)
@@ -39,12 +39,10 @@ export default class samp extends Core {
 
     // read players
     // don't even bother if > 100 players, because the server won't respond
-    let gotPlayerData = false
-    if (state.raw.numplayers < 100) {
+    if (state.numplayers < 100) {
       if (this.isVcmp) {
         const reader = await this.sendPacket('c', true)
         if (reader !== null) {
-          gotPlayerData = true
           const playerCount = reader.uint(2)
           for (let i = 0; i < playerCount; i++) {
             const player = {}
@@ -55,7 +53,6 @@ export default class samp extends Core {
       } else {
         const reader = await this.sendPacket('d', true)
         if (reader !== null) {
-          gotPlayerData = true
           const playerCount = reader.uint(2)
           for (let i = 0; i < playerCount; i++) {
             const player = {}
@@ -67,9 +64,6 @@ export default class samp extends Core {
           }
         }
       }
-    }
-    if (!gotPlayerData) {
-      state.numplayers = state.raw.numplayers
     }
   }
 

--- a/protocols/samp.js
+++ b/protocols/samp.js
@@ -69,7 +69,7 @@ export default class samp extends Core {
       }
     }
     if (!gotPlayerData) {
-      state.players.setNum(state.raw.numplayers)
+      state.numplayers = state.raw.numplayers
     }
   }
 

--- a/protocols/savage2.js
+++ b/protocols/savage2.js
@@ -7,7 +7,7 @@ export default class savage2 extends Core {
 
     reader.skip(12)
     state.name = this.stripColorCodes(reader.string())
-    state.players.setNum(reader.uint(1))
+    state.numplayers = reader.uint(1)
     state.maxplayers = reader.uint(1)
     state.raw.time = reader.string()
     state.map = reader.string()

--- a/protocols/starmade.js
+++ b/protocols/starmade.js
@@ -61,7 +61,7 @@ export default class starmade extends Core {
     if (typeof data[2] === 'string') state.name = data[2]
     if (typeof data[3] === 'string') state.raw.description = data[3]
     if (typeof data[4] === 'number') state.raw.startTime = data[4]
-    if (typeof data[5] === 'number') state.players.setNum(data[5])
+    if (typeof data[5] === 'number') state.numplayers = data[5]
     if (typeof data[6] === 'number') state.maxplayers = data[6]
   }
 }

--- a/protocols/teamspeak2.js
+++ b/protocols/teamspeak2.js
@@ -37,6 +37,7 @@ export default class teamspeak2 extends Core {
           })
           state.players.push(player)
         }
+        state.numplayers = state.players.length
       }
 
       {

--- a/protocols/teamspeak3.js
+++ b/protocols/teamspeak3.js
@@ -16,6 +16,7 @@ export default class teamspeak3 extends Core {
         state.raw = data[0]
         if ('virtualserver_name' in state.raw) state.name = state.raw.virtualserver_name
         if ('virtualserver_maxclients' in state.raw) state.maxplayers = state.raw.virtualserver_maxclients
+        if ('virtualserver_clientsonline' in state.raw) state.numplayers = state.raw.virtualserver_clientsonline
       }
 
       {

--- a/protocols/terraria.js
+++ b/protocols/terraria.js
@@ -19,6 +19,6 @@ export default class terraria extends Core {
 
     state.name = json.name
     state.gamePort = json.port
-    state.raw.numplayers = json.playercount
+    state.numplayers = json.playercount
   }
 }

--- a/protocols/tribes1.js
+++ b/protocols/tribes1.js
@@ -43,7 +43,7 @@ export default class tribes1 extends Core {
       state.raw.dedicated = !!reader.uint(1)
       state.raw.dropInProgress = !!reader.uint(1)
       state.raw.gameInProgress = !!reader.uint(1)
-      state.raw.playerCount = reader.uint(4)
+      state.numplayers = reader.uint(4)
       state.maxplayers = reader.uint(4)
       state.raw.teamPlay = reader.uint(1)
       state.map = this.readString(reader)

--- a/protocols/unreal2.js
+++ b/protocols/unreal2.js
@@ -18,7 +18,7 @@ export default class unreal2 extends Core {
       state.name = this.readUnrealString(reader, true)
       state.map = this.readUnrealString(reader, true)
       state.raw.gametype = this.readUnrealString(reader, true)
-      state.raw.numplayers = reader.uint(4)
+      state.numplayers = reader.uint(4)
       state.maxplayers = reader.uint(4)
       this.logger.debug(log => {
         log('UNREAL2 EXTRA INFO', reader.buffer.slice(reader.i))

--- a/protocols/valve.js
+++ b/protocols/valve.js
@@ -67,7 +67,7 @@ export default class valve extends Core {
     state.raw.folder = reader.string()
     state.raw.game = reader.string()
     if (!this.goldsrcInfo) state.raw.appId = reader.uint(2)
-    state.raw.numplayers = reader.uint(1)
+    state.numplayers = reader.uint(1)
     state.maxplayers = reader.uint(1)
 
     if (this.goldsrcInfo) state.raw.protocol = reader.uint(1)
@@ -301,7 +301,7 @@ export default class valve extends Core {
         state.name = rules.bat_name_s
         delete rules.bat_name_s
         if ('bat_player_count_s' in rules) {
-          state.raw.numplayers = parseInt(rules.bat_player_count_s)
+          state.numplayers = parseInt(rules.bat_player_count_s)
           delete rules.bat_player_count_s
         }
         if ('bat_max_players_i' in rules) {
@@ -427,16 +427,14 @@ export default class valve extends Core {
     })
     delete state.raw.players
     const numBots = state.raw.numbots || 0
-    const numPlayers = state.raw.numplayers - numBots
     while (state.bots.length < numBots) {
       if (sortedPlayers.length) state.bots.push(sortedPlayers.pop())
       else state.bots.push({})
     }
-    while (state.players.length < numPlayers || sortedPlayers.length) {
+    while (state.players.length < state.numplayers - numBots || sortedPlayers.length) {
       if (sortedPlayers.length) state.players.push(sortedPlayers.pop())
       else state.players.push({})
     }
-    state.numplayers = numPlayers
   }
 
   /**

--- a/protocols/valve.js
+++ b/protocols/valve.js
@@ -436,6 +436,7 @@ export default class valve extends Core {
       if (sortedPlayers.length) state.players.push(sortedPlayers.pop())
       else state.players.push({})
     }
+    state.numplayers = numPlayers
   }
 
   /**

--- a/protocols/ventrilo.js
+++ b/protocols/ventrilo.js
@@ -17,6 +17,7 @@ export default class ventrilo extends Core {
       state.players.push(client)
     }
     delete state.raw.CLIENTS
+    state.numplayers = state.players.length
 
     if ('NAME' in state.raw) state.name = state.raw.NAME
     if ('MAXCLIENTS' in state.raw) state.maxplayers = state.raw.MAXCLIENTS


### PR DESCRIPTION
Removes the setNum on players, as if the server doesn't report players, its just confusing to fill that field with empty objects.

Also stabilizes numplayers as many protocol already declare them and its a needed feature if the previously mentioned one was dropped.