### PR TITLE
fix: ARK: Survival Ascended `numplayers`

### DIFF
--- a/protocols/epic.js
+++ b/protocols/epic.js
@@ -76,6 +76,7 @@ export default class Epic extends Core {
     state.name = desiredServer.attributes.CUSTOMSERVERNAME_s
     state.map = desiredServer.attributes.MAPNAME_s
     state.password = desiredServer.attributes.SERVERPASSWORD_b
+    state.numplayers = desiredServer.totalPlayers
     state.maxplayers = desiredServer.settings.maxPublicPlayers
 
     for (const player of desiredServer.publicPlayers) {


### PR DESCRIPTION
Fixed the bug where `numplayers` was not populated when performing queries in the game ARK: Survival Ascended

Closes #404 

```
Results {
  name: 'BR PVE TribuFu 5x Ascended TheIsland',
  map: 'TheIsland_WP',
  password: false,
  raw: {
    deployment: 'ad9a8feffb3b4b2ca315546f038c3ae2',
    id: 'ef78140894af4e0bbef1d40733f6f09c',
    bucket: 'TestGameMode_C:<None>:TheIsland_WP',
    settings: {
      maxPublicPlayers: 70,
      allowInvites: true,
      shouldAdvertise: true,
      allowReadById: true,
      allowJoinViaPresence: true,
      allowJoinInProgress: true,
      allowConferenceRoom: false,
      checkSanctions: false,
      allowMigration: false,
      rejoinAfterKick: '',
      platforms: null
    },
    totalPlayers: 2,
    openPublicPlayers: 68,
    publicPlayers: [],
    started: false,
    lastUpdated: null,
    attributes: {
      MINORBUILDID_s: '11',
      MODID_l: 0,
      CUSTOMSERVERNAME_s: 'BR PVE TribuFu 5x Ascended TheIsland',
      ADDRESSDEV_s: '10.51.0.105,172.29.48.1,127.0.0.1',
      ISPRIVATE_l: 0,
      SERVERPASSWORD_b: false,
      MATCHTIMEOUT_d: 120,
      DAYTIME_s: '221',
      SOTFMATCHSTARTED_b: false,
      STEELSHIELDENABLED_l: 0,
      SERVERUSESBATTLEYE_b: true,
      EOSSERVERPING_l: 85,
      ALLOWDOWNLOADCHARS_l: 1,
      OFFICIALSERVER_s: '0',
      GAMEMODE_s: 'TestGameMode_C',
      ADDRESS_s: '189.90.255.6',
      SEARCHKEYWORDS_s: 'Custom',
      __EOS_BLISTENING_b: true,
      ALLOWDOWNLOADITEMS_l: 1,
      LEGACY_l: 0,
      ADDRESSBOUND_s: '0.0.0.0:7805',
      SESSIONISPVE_l: 1,
      __EOS_BUSESPRESENCE_b: true,
      SESSIONNAMEUPPER_s: 'BR PVE TRIBUFU 5X ASCENDED THEISLAND - (V26.11)',
      SERVERPLATFORMTYPE_s: 'All',
      MAPNAME_s: 'TheIsland_WP',
      BUILDID_s: '26',
      SESSIONNAME_s: 'BR PVE TribuFu 5x Ascended TheIsland - (v26.11)'
    },
    owner: 'Client_xyza7891muomRmynIIHaJB9COBKkwj6n',
    ownerPlatformId: null
  },
  maxplayers: 70,
  players: Players(0) [],
  bots: Players(0) [],
  numplayers: 2,
  connect: '189.90.255.6:7805',
  ping: 0
}
```