### PR TITLE
dns: Use node's built in isIP check instead of regex

### DIFF
--- a/lib/DnsResolver.js
+++ b/lib/DnsResolver.js
@@ -1,4 +1,5 @@
 import dns from 'node:dns'
+import { isIP } from 'node:net'
 import punycode from 'punycode/punycode.js'
 
 export default class DnsResolver {
@@ -9,12 +10,12 @@ export default class DnsResolver {
     this.logger = logger
   }
 
-  isIp (host) {
-    return !!host.match(/\d+\.\d+\.\d+\.\d+/)
-  }
-
   /**
-     * Response port will only be present if srv record was involved.
+     * Resolve a host name to its IP, if the given host name is already
+     * an IP address no request is made.
+     *
+     * If a srvRecordPrefix is provided a SRV request will be made and the
+     * port returned will be included in the output.
      * @param {string} host
      * @param {number} ipFamily
      * @param {string=} srvRecordPrefix
@@ -23,7 +24,8 @@ export default class DnsResolver {
   async resolve (host, ipFamily, srvRecordPrefix) {
     this.logger.debug('DNS Lookup: ' + host)
 
-    if (this.isIp(host)) {
+    // Check if host is IPv4 or IPv6
+    if (isIP(host) === 4 || isIP(host) === 6) {
       this.logger.debug('Raw IP Address: ' + host)
       return { address: host }
     }


### PR DESCRIPTION
Fixes #408 by replacing the old IP check with node's built-in check (compatible with Deno).

The IPv6 part of this is mostly irrelevant as I couldn't find any IPv6 game servers and the CLI doesn't handle IPv6 address properly anyway, but I left it in for future proofing.