### PR TITLE
fix: Update asa and epic protocols to use node require()

### DIFF
--- a/protocols/asa.js
+++ b/protocols/asa.js
@@ -1,6 +1,6 @@
-import Epic from './epic.js'
+const Epic = require('./epic');
 
-export default class asa extends Epic {
+class Asa extends Epic {
   constructor () {
     super()
 
@@ -10,3 +10,5 @@ export default class asa extends Epic {
     this.deploymentId = 'ad9a8feffb3b4b2ca315546f038c3ae2'
   }
 }
+
+module.exports = Asa;

--- a/protocols/epic.js
+++ b/protocols/epic.js
@@ -1,6 +1,6 @@
-import Core from './core.js'
+const Core = require('./core');
 
-export default class Epic extends Core {
+class Epic extends Core {
   constructor () {
     super()
 
@@ -100,3 +100,5 @@ export default class Epic extends Core {
     this.accessToken = null
   }
 }
+
+module.exports = Epic;


### PR DESCRIPTION
When cherry picking the commits in #416 , asa and epic protocols ended up using imports, which are not compatible with the other files using require.
