### PR TITLE
feat: add last oasis support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ see next point) and `tshock` (which is `terraria`).
 * Removed the players::setNum method, the library will no longer add empty players as 
 a placeholder in the `players` fields.
 * Stabilized field `numplayers`.
+* Last Oasis (2020) - Added support.
 
 ### 4.3.1
 * Fixed support for the Minecraft [Better Compatibility Checker](https://www.curseforge.com/minecraft/mc-mods/better-compatibility-checker) Mod (By @Douile, #436).

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -161,6 +161,7 @@
 | `kingpin`              | Kingpin: Life of Crime (1999)                           |                                                  |
 | `kisspc`               | Kiss: Psycho Circus: The Nightmare Child (2000)         |                                                  |
 | `kzmod`                | Kreedz Climbing (2017)                                  | [Valve Protocol](#valve)                         |
+| `lastoasis`            | Last Oasis (2020)                                       | [Valve Protocol](#valve)                         |
 | `left4dead`            | Left 4 Dead (2008)                                      | [Valve Protocol](#valve)                         |
 | `left4dead2`           | Left 4 Dead 2 (2009)                                    | [Valve Protocol](#valve)                         |
 | `m2mp`                 | Mafia II - Multiplayer (2010)                           |                                                  |

--- a/lib/games.js
+++ b/lib/games.js
@@ -1214,6 +1214,13 @@ export const games = {
       protocol: 'valve'
     }
   },
+  lastoasis: {
+    name: 'Last Oasis (2020)',
+    options: {
+      port: 27015,
+      protocol: 'valve'
+    }
+  },
   left4dead: {
     name: 'Left 4 Dead (2008)',
     options: {


### PR DESCRIPTION
Closes #248.
The game supports the valve query protocol and the default port for it is `27015` but I have managed to find only a server that I could have query (maybe cause some dont have the port open or they mapped it to another number), its this one: https://www.trackyserver.com/server/renegade-gaming-10x-all-pvp-pve-1330400 (IP: 184.67.182.202:5401) but it seems `numplayers` and `maxplayers` are wrongfully reported.