### PR TITLE
feat: add BeamMP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ see next point) and `tshock` (which is `terraria`).
 * Removed the players::setNum method, the library will no longer add empty players as 
 a placeholder in the `players` fields.
 * Stabilized field `numplayers`.
+* BeamMP (2021) - Added support.
 
 ### 4.3.1
 * Fixed support for the Minecraft [Better Compatibility Checker](https://www.curseforge.com/minecraft/mc-mods/better-compatibility-checker) Mod (By @Douile, #436).

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -31,6 +31,7 @@
 | `ballisticoverkill`    | Ballistic Overkill (2017)                               | [Valve Protocol](#valve)                         |
 | `barotrauma`           | Barotrauma (2019)                                       | [Valve Protocol](#valve)                         |
 | `bat1944`              | Battalion 1944 (2018)                                   | [Valve Protocol](#valve)                         |
+| `beammp`               | BeamMP (2021)                                           |                                                  |
 | `bf1942`               | Battlefield 1942 (2002)                                 |                                                  |
 | `bf2`                  | Battlefield 2 (2005)                                    |                                                  |
 | `bf2142`               | Battlefield 2142 (2006)                                 |                                                  |

--- a/lib/games.js
+++ b/lib/games.js
@@ -227,6 +227,13 @@ export const games = {
       protocol: 'valve'
     }
   },
+  beammp: {
+    name: 'BeamMP (2021)',
+    options: {
+      port: 30814,
+      protocol: 'beammp'
+    }
+  },
   bf1942: {
     name: 'Battlefield 1942 (2002)',
     options: {

--- a/protocols/beammp.js
+++ b/protocols/beammp.js
@@ -26,6 +26,7 @@ export default class beammp extends Core {
     players.forEach(player => {
       state.players.push({ name: player })
     })
+
     state.raw = server
   }
 }

--- a/protocols/beammp.js
+++ b/protocols/beammp.js
@@ -13,7 +13,7 @@ export default class beammp extends Core {
       throw new Error('Server not found in the master list')
     }
 
-    state.name = server.sname
+    state.name = server.sname.replace(/\^./g, '')
     state.map = server.map
     state.password = server.password
     state.numplayers = parseInt(server.players)

--- a/protocols/beammp.js
+++ b/protocols/beammp.js
@@ -1,0 +1,31 @@
+import Core from './core.js'
+import beammpmaster from './beammpmaster.js'
+
+export default class beammp extends Core {
+  async run (state) {
+    const master = new beammpmaster()
+    master.options = this.options
+    const masterState = await master.runOnceSafe()
+    const servers = masterState.raw.servers
+    const server = servers.find(s => s.ip === this.options.host)
+
+    if (!server) {
+      throw new Error('Server not found in the master list')
+    }
+
+    state.name = server.sname
+    state.map = server.map
+    state.password = server.password
+    state.numplayers = parseInt(server.players)
+    state.maxplayers = parseInt(server.players)
+
+    const players = server.playerslist.split(';')
+    if (players[players.length - 1] === '') {
+      players.pop()
+    }
+    players.forEach(player => {
+      state.players.push({ name: player })
+    })
+    state.raw = server
+  }
+}

--- a/protocols/beammpmaster.js
+++ b/protocols/beammpmaster.js
@@ -1,0 +1,17 @@
+import Core from './core.js'
+
+export default class beammpmaster extends Core {
+  constructor () {
+    super()
+
+    // Don't use the tcp ping probing
+    this.usedTcp = true
+  }
+
+  async run (state) {
+    state.raw.servers = await this.request({
+      url: 'https://backend.beammp.com/servers-info',
+      responseType: 'json'
+    })
+  }
+}

--- a/protocols/index.js
+++ b/protocols/index.js
@@ -48,11 +48,13 @@ import valve from './valve.js'
 import vcmp from './vcmp.js'
 import ventrilo from './ventrilo.js'
 import warsow from './warsow.js'
+import beammpmaster from './beammpmaster.js'
+import beammp from './beammp.js'
 
 export {
   armagetron, ase, asa, assettocorsa, battlefield, buildandshoot, cs2d, discord, doom3, eco, epic, ffow, fivem, gamespy1,
   gamespy2, gamespy3, geneshift, goldsrc, hexen2, jc2mp, kspdmp, mafia2mp, mafia2online, minecraft,
   minecraftbedrock, minecraftvanilla, mumble, mumbleping, nadeo, openttd, quake1, quake2, quake3, rfactor, samp,
   savage2, starmade, starsiege, teamspeak2, teamspeak3, terraria, tribes1, tribes1master, unreal2, ut3, valve,
-  vcmp, ventrilo, warsow, eldewrito
+  vcmp, ventrilo, warsow, eldewrito, beammpmaster, beammp
 }


### PR DESCRIPTION
Closes #340

I haven't found a way to query the server directly, but as provided in the linked issue (that requested this game), a master server is available, this implementation queries the master server and tries to find the server in the response list (and also processes it a bit if so).