### PR TITLE
fix(valve): dont skip players with no name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ see next point) and `tshock` (which is `terraria`).
 
 #### Games
 * Removed the players::setNum method, the library will no longer add empty players as 
-a placeholder in the `players` fields.
+placeholders in the `players` fields.
+* Valve: dont skip players with no name and keep state.raw.players.
 * Stabilized field `numplayers`.
 * BeamMP (2021) - Added support.
 

--- a/protocols/valve.js
+++ b/protocols/valve.js
@@ -188,9 +188,6 @@ export default class valve extends Core {
 
       this.logger.debug('Found player: ' + name + ' ' + score + ' ' + time)
 
-      // connecting players don't count as players.
-      if (!name) continue
-
       // CSGO sometimes adds a bot named 'Max Players' if host_players_show is not 2
       if (state.raw.appId === AppId.CSGO && name === 'Max Players') continue
 

--- a/protocols/valve.js
+++ b/protocols/valve.js
@@ -271,7 +271,7 @@ export default class valve extends Core {
     const sortedPlayers = state.raw.players.sort((a, b) => {
       return botProbability(a) - botProbability(b)
     })
-    delete state.raw.players
+
     const numBots = state.raw.numbots || 0
 
     while (state.bots.length < numBots && sortedPlayers.length) {


### PR DESCRIPTION
Commit 90e26bb and PR #389 removed the behaviour of adding players with empty data on the `numplayers` count, the valve protocol skipped adding players if their names are empty, some games (such as DayZ) provide players data (time played) but no names. Its better to have partial data than no data at all (beforehand this PR and the mentioned one, the query would return empty players data).