### PR TITLE
Add new data for DayZ state

### DIFF
--- a/protocols/dayz.js
+++ b/protocols/dayz.js
@@ -62,6 +62,10 @@ export default class dayz extends valve {
 
     state.raw.dlcEnabled = false
     state.raw.firstPerson = false
+    state.raw.privateHive = false
+    state.raw.external = false
+    state.raw.official = false
+
     for (const tag of state.raw.tags) {
       if (tag.startsWith('lqs')) {
         const value = parseInt(tag.replace('lqs', ''))
@@ -74,6 +78,12 @@ export default class dayz extends valve {
       }
       if (tag.includes('isDLC')) {
         state.raw.dlcEnabled = true
+      }
+      if (tag.includes('privHive')) {
+        state.raw.privateHive = true;
+      }
+      if (tag.includes('external')) {
+        state.raw.external = true;
       }
       if (tag.includes(':')) {
         state.raw.time = tag
@@ -90,6 +100,10 @@ export default class dayz extends valve {
           state.raw.nightAcceleration = value
         }
       }
+    }
+
+    if (!state.raw.external && !state.raw.privateHive) {
+      state.raw.official = true
     }
   }
 


### PR DESCRIPTION
Adds 3 news keys for DayZ:

```js
state.raw.privateHive
state.raw.external
state.raw.official
```

`privateHive` are usually community servers, and `external` does not appear on official servers. `official` is having `false` for both `privateHive` and `external`. I'm guessing this might be the case here, but I'm assuming things, since there's no documentation about this. Tested in several servers.