### PR TITLE
fix: remove deno hacky fixes

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -32,7 +32,7 @@ jobs:
         # uses: denoland/setup-deno@v1
         uses: denoland/setup-deno@61fe2df320078202e33d7d5ad347e7dcfa0e8f31  # v1.1.2
         with:
-          deno-version: v1.x
+          deno-version: v1.39.2
 
       - name: Compile
         run: deno compile --allow-net bin/gamedig.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ see next point) and `tshock` (which is `terraria`).
 * Added eslint which spotted some unused variables and other lints.
 * CLI: Resolved incorrect error message when querying with a non-existent protocol name.
 * Added Deno support: the library and CLI can now be experimentally used with the [Deno runtime](https://deno.com)
+  * Minimum Supported Deno Version: `1.39.2`.
   * `deno run --allow-net bin/gamedig.js --type tf2 127.0.0.1`
 * Added code examples.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node-GameDig - Game Server Query Library [![npmjs.com](https://img.shields.io/npm/dt/gamedig?color=purple)](https://www.npmjs.com/package/gamedig)
+# node-GameDig - Game Server Query Library [![npmjs.com](https://img.shields.io/npm/dt/gamedig?color=purple)](https://www.npmjs.com/package/gamedig) ![deno compatibility](https://shield.deno.dev/deno/1.39.2)
 
 **node-GameDig** is a game server query Node.js module (as well as a [command line executable](#usage-from-command-line)), 
 capable of querying for the status of nearly any game or voice server.

--- a/lib/GlobalUdpSocket.js
+++ b/lib/GlobalUdpSocket.js
@@ -18,10 +18,7 @@ export default class GlobalUdpSocket {
         type: 'udp4',
         reuseAddr: true
       })
-      // https://github.com/denoland/deno/issues/20138
-      if (typeof Deno === "undefined") {
-        udpSocket.unref();
-      }
+      udpSocket.unref()
       udpSocket.on('message', (buffer, rinfo) => {
         const fromAddress = rinfo.address
         const fromPort = rinfo.port

--- a/lib/QueryRunner.js
+++ b/lib/QueryRunner.js
@@ -68,21 +68,13 @@ export default class QueryRunner {
     for (const attempt of attempts) {
       for (let retry = 0; retry < numRetries; retry++) {
         attemptNum++
-        let result
+
         try {
-          result = await this._attempt(attempt)
+          return await this._attempt(attempt)
         } catch (e) {
           e.stack = 'Attempt #' + attemptNum + ' - Port=' + attempt.port + ' Retry=' + (retry) + ':\n' + e.stack
           errors.push(e)
-        } finally {
-          // Deno doesn't support unref, so we must close the socket after every connection
-          // https://github.com/denoland/deno/issues/20138
-          if (typeof Deno !== 'undefined') {
-            this.udpSocket?.socket?.close()
-            delete this.udpSocket
-          }
         }
-        if (result) return result
       }
     }
 


### PR DESCRIPTION
Closes #378.

> Deno `1.39.2` got released which includes added ref/unref for UDP in [Deno#21777](https://github.com/denoland/deno/pull/21777), I think it would be safe to remove the hacky fixes and mention that the Minimum Supported Deno Version is `1.39.2`.

This PR also added a 'Deno compatibility' badge to show the minimum supported deno version.