### PR TITLE
feat: Add valve requestRulesRequired & requestPlayersRequired

### DIFF
--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -87,7 +87,7 @@
 | daikatana            | Daikatana                                        |                                             |
 | dal                  | Dark and Light                                   | [Valve Protocol](#valve)                    |
 | dayofdragons         | Day of Dragons                                   | [Valve Protocol](#valve)                    |
-| dayz                 | DayZ                                             |                                             |
+| dayz                 | DayZ                                             | [Valve Protocol](#valve)                    |
 | dayzmod              | DayZ Mod                                         | [Valve Protocol](#valve)                    |
 | ddd                  | Dino D-Day                                       | [Valve Protocol](#valve)                    |
 | ddpt                 | Deadly Dozen: Pacific Theater                    |                                             |
@@ -440,7 +440,7 @@ additional option: `token`
 Valheim servers will only respond to queries if they are started in public mode (`-public 1`).
 
 ### DayZ
-DayZ stores some of it's servers information inside the `tags` attribute. Make sure to set `requestRules: true` to access it. Some data inside `dayzMods` attribute may be fuzzy, due to how mods are loaded into the servers. Alternatively, some servers may have a [third party tool](https://dayzsalauncher.com/#/tools) that you can use to get the mods information. If it's installed, you can access it via browser with the game servers IP:PORT, but add up 10 to the port. (eg. if game port is 2302 then use 2312).
+DayZ stores some of it's servers information inside the `tags` attribute. Make sure to set `requestRules: true` to access it. Some data inside `dayzMods` attribute may be fuzzy, due to how mods are loaded into the servers. Players can be fetched, but will not show ingame names. Alternatively, some servers may have a [third party tool](https://dayzsalauncher.com/#/tools) that you can use to get the mods information. If it's installed, you can access it via browser with the game servers IP:PORT, but add up 10 to the port. (eg. if game port is 2302 then use 2312).
 
 ### <a name="valve"></a>Valve Protocol
 For many valve games, additional 'rules' may be fetched into the unstable `raw` field by passing the additional
@@ -448,3 +448,6 @@ option: `requestRules: true`. Beware that this may increase query time.
 
 ### <a name="thefront"></a>The Front
 Responses with wrong `name` (gives out a steamid instead of the server name) and `maxplayers` (always 200, whatever the config would be) field values.
+
+### Conan Exiles
+Conan Exiles never responds to player query.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ These fields are all optional.
 * **ipFamily**: number - IP family/version returned when looking up hostnames via DNS, can be 0 (IPv4 and IPv6), 4 (IPv4 only) or 6 (IPv6 only). (default 0)
 * **debug**: boolean - Enables massive amounts of debug logging to stdout. (default false)
 * **requestRules**: boolean - Valve games only. Additional 'rules' may be fetched into the `raw` field. (default false)
+* **requestRulesRequired**: boolean - Valve games only. `requestRules` is always required to have a response or the query will timeout. (default false)
+* **requestPlayersRequired**: boolean - Valve games only. Querying players is always required to have a response or the query will timeout. Some [games](GAMES_LIST.md) may not provide a players response. (default false)
 
 ## Return Value
 

--- a/bin/gamedig.js
+++ b/bin/gamedig.js
@@ -6,7 +6,7 @@ import Minimist from 'minimist'
 import { GameDig } from './../lib/index.js'
 
 const argv = Minimist(process.argv.slice(2), {
-  boolean: ['pretty', 'debug', 'givenPortOnly', 'requestRules'],
+  boolean: ['pretty', 'debug', 'givenPortOnly', 'requestRules', 'requestRulesRequired'],
   string: ['guildId', 'listenUdpPort', 'ipFamily']
 })
 
@@ -16,6 +16,7 @@ const pretty = !!argv.pretty || debug
 delete argv.pretty
 const givenPortOnly = argv.givenPortOnly
 delete argv.givenPortOnly
+const requestRulesRequired = argv.requestRulesRequired
 
 const options = {}
 for (const key of Object.keys(argv)) {
@@ -39,6 +40,9 @@ if (debug) {
 }
 if (givenPortOnly) {
   options.givenPortOnly = true
+}
+if (requestRulesRequired) {
+  options.requestRulesRequired = true
 }
 
 const printOnPretty = (object) => {

--- a/bin/gamedig.js
+++ b/bin/gamedig.js
@@ -17,6 +17,7 @@ delete argv.pretty
 const givenPortOnly = argv.givenPortOnly
 delete argv.givenPortOnly
 const requestRulesRequired = argv.requestRulesRequired
+delete argv.requestRulesRequired
 
 const options = {}
 for (const key of Object.keys(argv)) {

--- a/bin/gamedig.js
+++ b/bin/gamedig.js
@@ -6,7 +6,7 @@ import Minimist from 'minimist'
 import { GameDig } from './../lib/index.js'
 
 const argv = Minimist(process.argv.slice(2), {
-  boolean: ['pretty', 'debug', 'givenPortOnly', 'requestRules', 'requestRulesRequired'],
+  boolean: ['pretty', 'debug', 'givenPortOnly', 'requestRules', 'requestRulesRequired', 'requestPlayersRequired'],
   string: ['guildId', 'listenUdpPort', 'ipFamily']
 })
 
@@ -18,6 +18,8 @@ const givenPortOnly = argv.givenPortOnly
 delete argv.givenPortOnly
 const requestRulesRequired = argv.requestRulesRequired
 delete argv.requestRulesRequired
+const requestPlayersRequired = argv.requestPlayersRequired
+delete argv.requestPlayersRequired
 
 const options = {}
 for (const key of Object.keys(argv)) {
@@ -44,6 +46,9 @@ if (givenPortOnly) {
 }
 if (requestRulesRequired) {
   options.requestRulesRequired = true
+}
+if (requestPlayersRequired) {
+  options.requestPlayersRequired = true
 }
 
 const printOnPretty = (object) => {

--- a/protocols/dayz.js
+++ b/protocols/dayz.js
@@ -25,7 +25,7 @@ export default class dayz extends valve {
     this.logger.debug('Requesting rules ...')
 
     const b = await this.sendPacket(0x56, null, 0x45, true)
-    if (b === null) return // timed out - the server probably has rules disabled
+    if (b === null && !this.options.requestRulesRequired) return // timed out - the server probably has rules disabled
 
     let dayZPayloadEnded = false
 

--- a/protocols/valve.js
+++ b/protocols/valve.js
@@ -170,7 +170,7 @@ export default class valve extends Core {
       true
     )
 
-    if (b === null) {
+    if (b === null && !this.options.requestPlayersRequired) {
       // Player query timed out
       // CSGO doesn't respond to player query if host_players_show is not 2
       // Conan Exiles never responds to player query

--- a/protocols/valve.js
+++ b/protocols/valve.js
@@ -214,7 +214,7 @@ export default class valve extends Core {
 
     if (this.goldsrcInfo) {
       const b = await this.udpSend('\xff\xff\xff\xffrules', b => b, () => null)
-      if (b === null) return // timed out - the server probably has rules disabled
+      if (b === null && !this.options.requestRulesRequired) return // timed out - the server probably has rules disabled
       const reader = this.reader(b)
       while (!reader.done()) {
         const key = reader.string()
@@ -222,7 +222,7 @@ export default class valve extends Core {
       }
     } else {
       const b = await this.sendPacket(0x56, null, 0x45, true)
-      if (b === null) return // timed out - the server probably has rules disabled
+      if (b === null && !this.options.requestRulesRequired) return // timed out - the server probably has rules disabled
 
       const reader = this.reader(b)
       const num = reader.uint(2)


### PR DESCRIPTION
Hello! This PR is about having all Valve queries required to have a response, otherwise the query will timeout. It will also work alongside `maxAttempts` so that all queries have a response, like suggested here (https://github.com/gamedig/node-gamedig/issues/455).

This PR adds:

- **requestRulesRequired**: boolean - Valve games only. `requestRules` is always required to have a response or the query will timeout. (default false)

- **requestPlayersRequired**: boolean - Valve games only. Querying players is always required to have a response or the query will timeout. Some [games](GAMES_LIST.md) may not provide a players response. (default false)

Also, I'm not sure I got it all working with the new options, so let me know if I should fix something. I tried to add all the code documentation inside the `README.md` and `GAMES_LIST.md`, so it's clearer how to look for more info.

Thank you!