### PR TITLE
chore: add new options to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
   * `deno run --allow-net bin/gamedig.js --type tf2 127.0.0.1`
 * Added code examples.
 * New option: `stripColors` (defaults to `true`) for protocols that strips colors: unreal2, savage2, quake3, nadeo, gamespy2, doom3, armagetron.
+* New option: `requestRulesRequired` (defaults to `false`) Valve games only. `requestRules` is always required to have a response or the query will timeout.
+* New option: `requestPlayersRequired` (defaults to `false`) Valve games only. Querying players is always required to have a response or the query will timeout. Some [games](GAMES_LIST.md) may not provide a players response.
 
 #### Games
 * Removed the players::setNum method, the library will no longer add empty players as 


### PR DESCRIPTION
This PR adds to the CHANGELOG:

- **requestRulesRequired**: boolean - Valve games only. requestRules is always required to have a response or the query will timeout. (default false)

- **requestPlayersRequired**: boolean - Valve [games](https://github.com/gamedig/node-gamedig/pull/GAMES_LIST.md) only. Querying players is always required to have a response or the query will timeout. Some games may not provide a players response. (default false)

Related to this other PR (https://github.com/gamedig/node-gamedig/pull/458)