### PR TITLE
feat: make port_query_offset accept a number or an array of numbers

### DIFF
--- a/lib/QueryRunner.js
+++ b/lib/QueryRunner.js
@@ -45,13 +45,9 @@ export default class QueryRunner {
       })
     }
 
-    let portOffsetArray = []
-    if (Array.isArray(gameQueryPortOffset)) {
-      portOffsetArray = gameQueryPortOffset
-    } else if (gameQueryPortOffset) {
-      portOffsetArray.push(gameQueryPortOffset)
-    } else {
-      portOffsetArray.push(0)
+    let portOffsetArray = gameQueryPortOffset
+    if (!Array.isArray(portOffsetArray)) {
+      gameQueryPortOffset ? portOffsetArray = [gameQueryPortOffset] : portOffsetArray = [0]
     }
 
     if (userOptions.port) {

--- a/lib/QueryRunner.js
+++ b/lib/QueryRunner.js
@@ -28,6 +28,7 @@ export default class QueryRunner {
     const {
       port_query: gameQueryPort,
       port_query_offset: gameQueryPortOffset,
+      port_query_offset_alt: gameQueryPortOffsetAlt,
       ...gameOptions
     } = lookup(userOptions.type)
     const attempts = []
@@ -47,7 +48,9 @@ export default class QueryRunner {
 
     if (userOptions.port) {
       if (!userOptions.givenPortOnly) {
-        if (gameQueryPortOffset) { addAttemptWithPort(userOptions.port + gameQueryPortOffset) }
+        if (gameQueryPortOffset) {addAttemptWithPort(userOptions.port + gameQueryPortOffset) }
+
+        if (gameQueryPortOffsetAlt) { addAttemptWithPort(userOptions.port + gameQueryPortOffsetAlt) }
 
         if (userOptions.port === gameOptions.port && gameQueryPort) { addAttemptWithPort(gameQueryPort) }
       }

--- a/lib/QueryRunner.js
+++ b/lib/QueryRunner.js
@@ -28,7 +28,6 @@ export default class QueryRunner {
     const {
       port_query: gameQueryPort,
       port_query_offset: gameQueryPortOffset,
-      port_query_offset_alt: gameQueryPortOffsetAlt,
       ...gameOptions
     } = lookup(userOptions.type)
     const attempts = []
@@ -48,18 +47,34 @@ export default class QueryRunner {
 
     if (userOptions.port) {
       if (!userOptions.givenPortOnly) {
-        if (gameQueryPortOffset) {addAttemptWithPort(userOptions.port + gameQueryPortOffset) }
 
-        if (gameQueryPortOffsetAlt) { addAttemptWithPort(userOptions.port + gameQueryPortOffsetAlt) }
+        if (gameQueryPortOffset) {
+          if (Array.isArray(gameQueryPortOffset)) {
+            gameQueryPortOffset.forEach((portOffset) => addAttemptWithPort(userOptions.port + portOffset))
+          } else {
+            addAttemptWithPort(userOptions.port + gameQueryPortOffset)
+          }
+        }
 
         if (userOptions.port === gameOptions.port && gameQueryPort) { addAttemptWithPort(gameQueryPort) }
       }
 
       attempts.push(optionsCollection)
+
     } else if (gameQueryPort) {
       addAttemptWithPort(gameQueryPort)
     } else if (gameOptions.port) {
-      addAttemptWithPort(gameOptions.port + (gameQueryPortOffset || 0))
+
+      if (gameQueryPortOffset) {
+        if (Array.isArray(gameQueryPortOffset)) {
+          gameQueryPortOffset.forEach((portOffset) => addAttemptWithPort(userOptions.port + portOffset))
+        } else {
+          addAttemptWithPort(userOptions.port + gameQueryPortOffset)
+        }
+      } else {
+        addAttemptWithPort(userOptions.port)
+      }
+
     } else {
       // Hopefully the request doesn't need a port. If it does, it'll fail when making the request.
       attempts.push(optionsCollection)

--- a/lib/QueryRunner.js
+++ b/lib/QueryRunner.js
@@ -45,36 +45,25 @@ export default class QueryRunner {
       })
     }
 
+    let portOffsetArray = []
+    if (Array.isArray(gameQueryPortOffset)) {
+      portOffsetArray = gameQueryPortOffset
+    } else if (gameQueryPortOffset) {
+      portOffsetArray.push(gameQueryPortOffset)
+    } else {
+      portOffsetArray.push(0)
+    }
+
     if (userOptions.port) {
       if (!userOptions.givenPortOnly) {
-
-        if (gameQueryPortOffset) {
-          if (Array.isArray(gameQueryPortOffset)) {
-            gameQueryPortOffset.forEach((portOffset) => addAttemptWithPort(userOptions.port + portOffset))
-          } else {
-            addAttemptWithPort(userOptions.port + gameQueryPortOffset)
-          }
-        }
-
+        portOffsetArray.forEach((portOffset) => { addAttemptWithPort(userOptions.port + portOffset) })
         if (userOptions.port === gameOptions.port && gameQueryPort) { addAttemptWithPort(gameQueryPort) }
       }
-
       attempts.push(optionsCollection)
-
     } else if (gameQueryPort) {
       addAttemptWithPort(gameQueryPort)
     } else if (gameOptions.port) {
-
-      if (gameQueryPortOffset) {
-        if (Array.isArray(gameQueryPortOffset)) {
-          gameQueryPortOffset.forEach((portOffset) => addAttemptWithPort(userOptions.port + portOffset))
-        } else {
-          addAttemptWithPort(userOptions.port + gameQueryPortOffset)
-        }
-      } else {
-        addAttemptWithPort(userOptions.port)
-      }
-
+      portOffsetArray.forEach((portOffset) => { addAttemptWithPort(gameOptions.port + portOffset) })
     } else {
       // Hopefully the request doesn't need a port. If it does, it'll fail when making the request.
       attempts.push(optionsCollection)

--- a/lib/games.js
+++ b/lib/games.js
@@ -2656,8 +2656,7 @@ export const games = {
     name: 'V Rising',
     options: {
       port: 27015,
-      port_query_offset: 1,
-      port_query_offset_alt: 15,
+      port_query_offset: [1, 15],
       protocol: 'valve'
     },
     release_year: 2022

--- a/lib/games.js
+++ b/lib/games.js
@@ -2656,7 +2656,7 @@ export const games = {
     name: 'V Rising',
     options: {
       port: 27015,
-      port_query_offset: [1, 15],
+      port_query_offset: 1,
       protocol: 'valve'
     },
     release_year: 2022

--- a/lib/games.js
+++ b/lib/games.js
@@ -2657,6 +2657,7 @@ export const games = {
     options: {
       port: 27015,
       port_query_offset: 1,
+      port_query_offset_alt: 15,
       protocol: 'valve'
     },
     release_year: 2022


### PR DESCRIPTION
Hello!

This PR adds an alternative `port_query_offset`. I'm not sure if this all it needs to add an alternative `port_query_offset`, but it worked on the tests I did.

Currently with an option in the game `V Rising`. Related to this issue (https://github.com/gamedig/node-gamedig/issues/438).