### PR TITLE
chore: add 'protocol-' mention on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Confused on how this works, or you want to see more? Checkout the [examples](/ex
 
 | Field    | Type   | Description                                                    |
 |:---------|:-------|:---------------------------------------------------------------|
-| **type** | string | One of the game IDs listed in the [games list](GAMES_LIST.md). |
+| **type** | string | One of the game type IDs listed in the [games list](GAMES_LIST.md). Or you can use `protocol-[name]` to select a specific protocol. Protocols are listed [here](protocols/index.js). |
 | **host** | string | Hostname or IP of the game server.                             |
 
 ## Optional Fields


### PR DESCRIPTION
Adds a mention about `protocol-` usage in README.
It also closes https://github.com/gamedig/node-gamedig/pull/303.