### PR TITLE
feat: Add debug option to 'attempt_protocols' tool

### DIFF
--- a/tools/attempt_protocols.js
+++ b/tools/attempt_protocols.js
@@ -12,6 +12,7 @@ if (argv._.length >= 1) {
   if (split.length >= 2) {
     options.port = split[1]
   }
+  options.debug = argv._[1] === 'debug'
 }
 
 const gamedig = new GameDig(options)
@@ -28,7 +29,6 @@ const run = async () => {
     try {
       const response = await gamedig.query({
         ...options,
-        debug: true,
         type: `protocol-${protocol}`
       })
       console.log(response)


### PR DESCRIPTION
Adds a debug option to the 'attempt_protocols' tool. Default is `false`.

`node tools/attempt_protocols 123.123.123.123 debug`