### PR TITLE
chore: add Minecraft notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ placeholders in the `players` fields.
 * Stabilized field `numplayers`.
 * Add note about EOS Protocol not providing players data.
 * V Rising (2022) - Updated `options.port_query_offset` to `[1, 15]` (#438).
+* Minecraft (2009) - Add note about players data
 * BeamMP (2021) - Added support.
 * Xonotic (2011) - Added support.
 * Call of Duty: Black Ops 3 (2015) - Added support.

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -171,7 +171,7 @@
 | mbe                  | Minecraft: Bedrock Edition                       |                                                 |
 | medievalengineers    | Medieval Engineers                               | [Valve Protocol](#valve)                        |
 | mgm                  | Mumble - GT Murmur                               | [Notes](#mumble)                                |
-| minecraft            | Minecraft                                        |                                                 |
+| minecraft            | Minecraft                                        | [Notes](#minecraft)                             |
 | mnc                  | Monday Night Combat                              | [Valve Protocol](#valve)                        |
 | moh                  | Medal of Honor                                   |                                                 |
 | moha                 | Medal of Honor: Airborne                         |                                                 |
@@ -451,6 +451,8 @@ Responses with wrong `name` (gives out a steamid instead of the server name) and
 ### <a name="conanexiles">Conan Exiles
 Conan Exiles never responds to player query.
 
+### <a name="minecraft">Minecraft
+Many Minecraft servers do not respond with players data.
 
 Protocols with Additional Notes
 ---

--- a/lib/games.js
+++ b/lib/games.js
@@ -1517,6 +1517,9 @@ export const games = {
       port: 25565,
       protocol: 'minecraft'
     },
+    extra: {
+      doc_notes: 'minecraft'
+    },
     release_year: 2009
   },
   mbe: {


### PR DESCRIPTION
Adds the following note about Minecraft. It closes this issue https://github.com/gamedig/node-gamedig/issues/304.

```
Many Minecraft servers do not respond with players data.
```