### PR TITLE
feat: add support for Palworld

### DIFF
--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -203,6 +203,7 @@
 | openarena            | OpenArena                                        |                                                 |
 | openttd              | OpenTTD                                          |                                                 |
 | painkiller           | Painkiller                                       |                                                 |
+| palworld             | Palworld                                         | [EOS Protocol](#eos)                            |
 | pce                  | Primal Carnage: Extinction                       | [Valve Protocol](#valve)                        |
 | pixark               | PixARK                                           | [Valve Protocol](#valve)                        |
 | postal2              | Postal 2                                         |                                                 |

--- a/lib/games.js
+++ b/lib/games.js
@@ -1751,6 +1751,14 @@ export const games = {
     },
     release_year: 2004
   },
+  palworld: {
+    name: 'Palworld',
+    release_year: 2024,
+    options: {
+      port: 8221,
+      protocol: 'palworld'
+    }
+  },
   pvak2: {
     name: 'Pirates, Vikings, and Knights II',
     options: {

--- a/protocols/epic.js
+++ b/protocols/epic.js
@@ -15,7 +15,8 @@ export default class Epic extends Core {
     this.clientSecret = null
     this.deploymentId = null
     this.epicApi = 'https://api.epicgames.dev'
-    this.clientAccessToken = null
+    this.alternativeAuth = false // Some games require a client access token to POST to the matchmaking endpoint.
+
     this.deviceIdAccessToken = null
     this.accessToken = null
 
@@ -24,15 +25,18 @@ export default class Epic extends Core {
   }
 
   async run (state) {
-    await this.getClientAccessToken()
-    await this.getDeviceIdToken()
-    await this.getAuthAccessToken()
+    if (this.alternativeAuth) {
+      await this.getExternalAccessToken()
+    } else {
+      await this.getClientAccessToken()
+    }
+
     await this.queryInfo(state)
     await this.cleanup(state)
   }
 
   async getClientAccessToken () {
-    this.logger.debug('Requesting acess token ...')
+    this.logger.debug('Requesting client access token ...')
 
     const url = `${this.epicApi}/auth/v1/oauth/token`
     const body = `grant_type=client_credentials&deployment_id=${this.deploymentId}`
@@ -44,11 +48,11 @@ export default class Epic extends Core {
     this.logger.debug(`POST: ${url}`)
     const response = await this.request({ url, body, headers, method: 'POST', responseType: 'json' })
 
-    this.clientAccessToken = response.access_token
+    this.accessToken = response.access_token
   }
 
-  async getDeviceIdToken () {
-    this.logger.debug('Requesting acess token ...')
+  async _getDeviceIdToken () {
+    this.logger.debug('Requesting deviceId access token ...')
 
     const url = `${this.epicApi}/auth/v1/accounts/deviceid`
     const body = 'deviceModel=PC'
@@ -60,14 +64,26 @@ export default class Epic extends Core {
     this.logger.debug(`POST: ${url}`)
     const response = await this.request({ url, body, headers, method: 'POST', responseType: 'json' })
 
-    this.deviceIdAccessToken = response.access_token
+    return response.access_token
   }
 
-  async getAuthAccessToken () {
-    this.logger.debug('Requesting acess token ...')
+  async getExternalAccessToken () {
+    this.logger.debug('Requesting external access token ...')
+
+    const deviceIdToken = await this._getDeviceIdToken()
 
     const url = `${this.epicApi}/auth/v1/oauth/token`
-    const body = `grant_type=external_auth&external_auth_type=deviceid_access_token&external_auth_token=${this.deviceIdAccessToken}&nonce=ABCHFA3qgUCJ1XTPAoGDEF&deployment_id=${this.deploymentId}&display_name=User`
+
+    const bodyParts = [
+      'grant_type=external_auth',
+      'external_auth_type=deviceid_access_token',
+      `external_auth_token=${deviceIdToken}`,
+      'nonce=ABCHFA3qgUCJ1XTPAoGDEF', // This is required but can be set to anything
+      `deployment_id=${this.deploymentId}`,
+      'display_name=User'
+    ]
+
+    const body = bodyParts.join('&')
     const headers = {
       Authorization: `Basic ${Buffer.from(`${this.clientId}:${this.clientSecret}`).toString('base64')}`,
       'Content-Type': 'application/x-www-form-urlencoded'

--- a/protocols/epic.js
+++ b/protocols/epic.js
@@ -15,7 +15,7 @@ export default class Epic extends Core {
     this.clientSecret = null
     this.deploymentId = null
     this.epicApi = 'https://api.epicgames.dev'
-    this.alternativeAuth = false // Some games require a client access token to POST to the matchmaking endpoint.
+    this.authByExternalToken = false // Some games require a client access token to POST to the matchmaking endpoint.
 
     this.deviceIdAccessToken = null
     this.accessToken = null
@@ -25,7 +25,7 @@ export default class Epic extends Core {
   }
 
   async run (state) {
-    if (this.alternativeAuth) {
+    if (this.authByExternalToken) {
       await this.getExternalAccessToken()
     } else {
       await this.getClientAccessToken()

--- a/protocols/index.js
+++ b/protocols/index.js
@@ -29,6 +29,7 @@ import mumble from './mumble.js'
 import mumbleping from './mumbleping.js'
 import nadeo from './nadeo.js'
 import openttd from './openttd.js'
+import palworld from './palworld.js'
 import quake1 from './quake1.js'
 import quake2 from './quake2.js'
 import quake3 from './quake3.js'
@@ -55,7 +56,7 @@ import dayz from './dayz.js'
 export {
   armagetron, ase, asa, assettocorsa, battlefield, buildandshoot, cs2d, discord, doom3, eco, epic, ffow, fivem, gamespy1,
   gamespy2, gamespy3, geneshift, goldsrc, hexen2, jc2mp, kspdmp, mafia2mp, mafia2online, minecraft,
-  minecraftbedrock, minecraftvanilla, mumble, mumbleping, nadeo, openttd, quake1, quake2, quake3, rfactor, samp,
+  minecraftbedrock, minecraftvanilla, mumble, mumbleping, nadeo, openttd, palworld, quake1, quake2, quake3, rfactor, samp,
   savage2, starmade, starsiege, teamspeak2, teamspeak3, terraria, tribes1, tribes1master, unreal2, ut3, valve,
   vcmp, ventrilo, warsow, eldewrito, beammpmaster, beammp, dayz
 }

--- a/protocols/palworld.js
+++ b/protocols/palworld.js
@@ -8,6 +8,6 @@ export default class palworld extends Epic {
     this.clientId = 'xyza78916PZ5DF0fAahu4tnrKKyFpqRE'
     this.clientSecret = 'j0NapLEPm3R3EOrlQiM8cRLKq3Rt02ZVVwT0SkZstSg'
     this.deploymentId = '0a18471f93d448e2a1f60e47e03d3413'
-    this.alternativeAuth = true;
+    this.authByExternalToken = true
   }
 }

--- a/protocols/palworld.js
+++ b/protocols/palworld.js
@@ -1,0 +1,12 @@
+import Epic from './epic.js'
+
+export default class palworld extends Epic {
+  constructor () {
+    super()
+
+    // OAuth2 credentials extracted from Palworld files.
+    this.clientId = 'xyza78916PZ5DF0fAahu4tnrKKyFpqRE'
+    this.clientSecret = 'j0NapLEPm3R3EOrlQiM8cRLKq3Rt02ZVVwT0SkZstSg'
+    this.deploymentId = '0a18471f93d448e2a1f60e47e03d3413'
+  }
+}

--- a/protocols/palworld.js
+++ b/protocols/palworld.js
@@ -8,5 +8,6 @@ export default class palworld extends Epic {
     this.clientId = 'xyza78916PZ5DF0fAahu4tnrKKyFpqRE'
     this.clientSecret = 'j0NapLEPm3R3EOrlQiM8cRLKq3Rt02ZVVwT0SkZstSg'
     this.deploymentId = '0a18471f93d448e2a1f60e47e03d3413'
+    this.alternativeAuth = true;
   }
 }


### PR DESCRIPTION
Worth noting that this will only query game servers that are listed in EOS matchmaking. I've noticed at the moment that Palworld, as it's currently booming in popularity, does not include all game servers on it's matchmaking list.

You can also see currently when you host a dedicated server, that the "create session" requests that are made to EOS often fail. When this happens, the game server does not appear in EOS and you can only directly connect in-game.

As far as I'm aware there's not currently a way to directly query a Palworld server.