### PR TITLE
Fix: Palworld results - Name of the server is empty

### DIFF
--- a/protocols/epic.js
+++ b/protocols/epic.js
@@ -126,18 +126,13 @@ export default class Epic extends Core {
       throw new Error('Server not found')
     }
 
-    if (
-      desiredServer.attributes.NAME_s !== undefined &&
-      desiredServer.attributes.NAME_s !== null &&
-      desiredServer.attributes.NAME_s !== ''
-    ) {
-      state.name = desiredServer.attributes.NAME_s;
-    } else if (
-      desiredServer.attributes.CUSTOMSERVERNAME_s !== undefined &&
-      desiredServer.attributes.CUSTOMSERVERNAME_s !== null &&
-      desiredServer.attributes.CUSTOMSERVERNAME_s !== ''
-    ) {
-      state.name = desiredServer.attributes.CUSTOMSERVERNAME_s;
+    const name = desiredServer.attributes.NAME_s
+    const customName = desiredServer.attributes.CUSTOMSERVERNAME_s
+
+    if (name && name !== '') {
+      state.name = name;
+    } else if (customName && customName !== '') {
+      state.name = customName;
     } else {
       state.name = '';
     }

--- a/protocols/epic.js
+++ b/protocols/epic.js
@@ -126,16 +126,7 @@ export default class Epic extends Core {
       throw new Error('Server not found')
     }
 
-    const name = desiredServer.attributes.NAME_s
-    const customName = desiredServer.attributes.CUSTOMSERVERNAME_s
-
-    if (name && name !== '') {
-      state.name = name;
-    } else if (customName && customName !== '') {
-      state.name = customName;
-    } else {
-      state.name = '';
-    }
+    state.name = desiredServer.attributes.CUSTOMSERVERNAME_s
     state.map = desiredServer.attributes.MAPNAME_s
     state.password = desiredServer.attributes.SERVERPASSWORD_b
     state.numplayers = desiredServer.totalPlayers

--- a/protocols/epic.js
+++ b/protocols/epic.js
@@ -126,7 +126,21 @@ export default class Epic extends Core {
       throw new Error('Server not found')
     }
 
-    state.name = desiredServer.attributes.CUSTOMSERVERNAME_s
+    if (
+      desiredServer.attributes.NAME_s !== undefined &&
+      desiredServer.attributes.NAME_s !== null &&
+      desiredServer.attributes.NAME_s !== ''
+    ) {
+      state.name = desiredServer.attributes.NAME_s;
+    } else if (
+      desiredServer.attributes.CUSTOMSERVERNAME_s !== undefined &&
+      desiredServer.attributes.CUSTOMSERVERNAME_s !== null &&
+      desiredServer.attributes.CUSTOMSERVERNAME_s !== ''
+    ) {
+      state.name = desiredServer.attributes.CUSTOMSERVERNAME_s;
+    } else {
+      state.name = '';
+    }
     state.map = desiredServer.attributes.MAPNAME_s
     state.password = desiredServer.attributes.SERVERPASSWORD_b
     state.numplayers = desiredServer.totalPlayers

--- a/protocols/palworld.js
+++ b/protocols/palworld.js
@@ -10,4 +10,9 @@ export default class palworld extends Epic {
     this.deploymentId = '0a18471f93d448e2a1f60e47e03d3413'
     this.authByExternalToken = true
   }
+
+  async run (state) {
+    await super.run(state)
+    state.name = state.raw.attributes.NAME_s
+  }
 }


### PR DESCRIPTION
While ASSA returns something in CUSTOMSERVERNAME_s, Palworld returns that on epic as empty, but NAME_s is set with the servername.

Can be tested with:
npx gamedig --debug --type palworld 148.251.89.181:8211
npx gamedig --debug --type asa 148.251.89.181:7783
Both servers are only and from me.


@CosminPerRam Please feel free to improove quality on this fix, you know my skill-level on Javascript 😎  