### PR TITLE
feat: add Duke Nukem Forever 2001 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ placeholders in the `players` fields.
 * Call of Duty: Black Ops 3 (2015) - Added support.
 * Unreal 2: The Awakening - XMP - Added support.
 * Palworld - Added support (By @jonathanprl, #495).
+* Duke Nukem Forever 2001 (2022) - Added support.
 
 ### 4.3.1
 * Fixed support for the Minecraft [Better Compatibility Checker](https://www.curseforge.com/minecraft/mc-mods/better-compatibility-checker) Mod (By @Douile, #436).

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -101,6 +101,7 @@
 | discord              | Discord                                          | [Notes](#discord)                               |
 | dmomam               | Dark Messiah of Might and Magic                  | [Valve Protocol](#valve)                        |
 | dod                  | Day of Defeat                                    | [Valve Protocol](#valve)                        |
+| dnf2001              | Duke Nukem Forever 2001                          |                                                 |
 | dods                 | Day of Defeat: Source                            | [Valve Protocol](#valve)                        |
 | doi                  | Day of Infamy                                    | [Valve Protocol](#valve)                        |
 | doom3                | Doom 3                                           |                                                 |

--- a/lib/games.js
+++ b/lib/games.js
@@ -864,6 +864,15 @@ export const games = {
       protocol: 'valve'
     }
   },
+  dnf2001: {
+    name: 'Duke Nukem Forever 2001',
+    release_year: 2022,
+    options: {
+      port: 7777,
+      port_query_offset: 1,
+      protocol: 'gamespy1'
+    }
+  },
   dod: {
     name: 'Day of Defeat',
     release_year: 2003,


### PR DESCRIPTION
Adds support for Duke Nukem Forever 2001. 
Thanks @cetteup for testing and pointing the protocol! See more at https://github.com/gamedig/node-gamedig/issues/298

I'm not 100% sure about and could use a confirmation:

```
release_year: 2022, 
port: 7777, 
port_query_offset: 1
```

—

Example response:

```js
node bin/gamedig --type dnf2001 45.89.125.89 --pretty

{
  "name": "The Gravel Pit | EU",
  "map": "DM-64-LivesAgain",
  "password": false,
  "raw": {
    "gamename": "dnf",
    "gamever": 400,
    "minnetver": 400,
    "location": 0,
    "hostname": "The Gravel Pit | EU",
    "hostport": 7777,
    "maptitle": "Untitled",
    "mapname": "DM-64-LivesAgain",
    "gametype": "dnDeathmatchGame",
    "numplayers": 0,
    "maxplayers": 16,
    "gamemode": "openplaying",
    "worldlog": true,
    "listenserver": false,
    "timelimit": 10,
    "fraglimit": 35,
    "minplayers": 0,
    "changelevels": true,
    "adminname": "EduCatOR",
    "teams": {}
  },
  "maxplayers": 16,
  "numplayers": 0,
  "players": [],
  "bots": [],
  "queryPort": 7778,
  "connect": "45.89.125.89:7777",
  "ping": 306
}
```