### PR TITLE
fix: remove query_port and fix those with the use of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,9 @@ placeholders in the `players` fields.
 * Stabilized field `numplayers`.
 * Add note about EOS Protocol not providing players data.
 * V Rising (2022) - Updated `options.port_query_offset` to `[1, 15]` (#438).
-* Minecraft (2009) - Add note about players data
+* Minecraft (2009) - Add note about players data.
+* Fixed Project Cars and Project Cars 2 port offsets.
+* Fixed Wurm Unlimited port_query being missnamed.
 * BeamMP (2021) - Added support.
 * Xonotic (2011) - Added support.
 * Call of Duty: Black Ops 3 (2015) - Added support.

--- a/lib/games.js
+++ b/lib/games.js
@@ -2099,7 +2099,7 @@ export const games = {
     release_year: 2015,
     options: {
       port: 27015,
-      query_port: 1,
+      port_query_offset: 1,
       protocol: 'valve'
     },
     extra: {
@@ -2111,7 +2111,7 @@ export const games = {
     release_year: 2017,
     options: {
       port: 27015,
-      query_port: 1,
+      port_query_offset: 1,
       protocol: 'valve'
     },
     extra: {
@@ -2797,7 +2797,7 @@ export const games = {
     extra: {
       old_id: 'terraria',
       doc_notes: 'terraria'
-    },
+    }
   },
   theforest: {
     name: 'The Forest',
@@ -3151,7 +3151,7 @@ export const games = {
     release_year: 2006,
     options: {
       port: 3724,
-      query_port: 27016,
+      port_query: 27016,
       protocol: 'valve'
     },
     extra: {


### PR DESCRIPTION
Removed instances of `query_port` from the games that were using it and fixed these game's ports (Project Cars, Project Cars 2 and Wurm Unlimited), this was a mistype, as it should have been `port_query`.
Also mentioned in #502.