### PR TITLE
feat: add support for Enshrouded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ placeholders in the `players` fields.
 * Unreal 2: The Awakening - XMP - Added support.
 * Palworld - Added support (By @jonathanprl, #495).
 * The Isle Evrima - Added support (By @GuilhermeWerner, #501).
+* Enshrouded - Added support (By @GuilhermeWerner).
 
 ### 4.3.1
 * Fixed support for the Minecraft [Better Compatibility Checker](https://www.curseforge.com/minecraft/mc-mods/better-compatibility-checker) Mod (By @Douile, #436).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## To Be Released...
 ## 5.0.0-beta.1
 * Fixed numplayers on Palworld not beeing accurate
+* Enshrouded - Added support (By @GuilhermeWerner #512).
 
 ## 5.0.0-beta.0
 ### Breaking Changes
@@ -63,7 +64,6 @@ placeholders in the `players` fields.
 * Unreal 2: The Awakening - XMP - Added support.
 * Palworld - Added support (By @jonathanprl, #495).
 * The Isle Evrima - Added support (By @GuilhermeWerner, #501).
-* Enshrouded - Added support (By @GuilhermeWerner).
 
 ### 4.3.1
 * Fixed support for the Minecraft [Better Compatibility Checker](https://www.curseforge.com/minecraft/mc-mods/better-compatibility-checker) Mod (By @Douile, #436).

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -114,6 +114,7 @@
 | egs                  | Empyrion - Galactic Survival                     | [Valve Protocol](#valve)                        |
 | eldewrito            | Halo Online (ElDewrito)                          |                                                 |
 | empiresmod           | Empires Mod                                      | [Valve Protocol](#valve)                        |
+| enshrouded           | Enshrouded                                       | [Valve Protocol](#valve)                        |
 | etqw                 | Enemy Territory: Quake Wars                      |                                                 |
 | f1c9902              | F1 Challenge '99-'02                             |                                                 |
 | farcry               | Far Cry                                          |                                                 |

--- a/lib/games.js
+++ b/lib/games.js
@@ -1098,6 +1098,15 @@ export const games = {
       old_id: 'empyrion'
     }
   },
+  enshrouded: {
+    name: 'enshrouded',
+    release_year: 2024,
+    options: {
+      port: 15636,
+      port_query: 15637,
+      protocol: 'valve'
+    }
+  },
   etqw: {
     name: 'Enemy Territory: Quake Wars',
     release_year: 2007,


### PR DESCRIPTION
### This PR adds

Support for Enshrouded using Valve protocol.

Closes #505

### Protocol and Ports:

The game responds successfully when using the valve protocol, and in the server settings it is possible to see the default ports that this PR was based on:

![image](https://github.com/gamedig/node-gamedig/assets/26710260/3d71fefa-3d29-4bdc-9c2d-4baea5c5135c)

### Tests:

My test server:

```sh
node .\bin\gamedig.js --type enshrouded 189.90.255.6 15637

{
    "name": "Enshrouded Server",
    "map": "",
    "password": false,
    "raw": {
        "protocol": 17,
        "folder": "Enshrouded",
        "game": "Enshrouded",
        "appId": 1203620,
        "numbots": 0,
        "listentype": "d",
        "environment": "w",
        "secure": 0,
        "version": "0.0.15.0",
        "steamid": "90179849730323478",
        "tags": [
            "1;487046"
        ],
        "players": []
    },
    "maxplayers": 16,
    "numplayers": 0,
    "players": [],
    "bots": [],
    "queryPort": 15637,
    "connect": "189.90.255.6:15636",
    "ping": 30
}
```