### PR TITLE
chore: Add EOS notes on Palworld and The Isle Evrima

### DIFF
--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -205,7 +205,7 @@
 | openarena            | OpenArena                                        |                                                 |
 | openttd              | OpenTTD                                          |                                                 |
 | painkiller           | Painkiller                                       |                                                 |
-| palworld             | Palworld                                         |                                                 |
+| palworld             | Palworld                                         | [EOS Protocol](#epic)                           |
 | pce                  | Primal Carnage: Extinction                       | [Valve Protocol](#valve)                        |
 | pixark               | PixARK                                           | [Valve Protocol](#valve)                        |
 | postal2              | Postal 2                                         |                                                 |
@@ -289,7 +289,7 @@
 | thefront             | The Front                                        | [Valve Protocol](#valve)                        |
 | thehidden            | The Hidden                                       | [Valve Protocol](#valve)                        |
 | theisle              | The Isle                                         | [Valve Protocol](#valve)                        |
-| tie                  | The Isle Evrima                                  |                                                 |
+| tie                  | The Isle Evrima                                  | [EOS Protocol](#epic)                           |
 | theship              | The Ship                                         | [Valve Protocol](#valve)                        |
 | thespecialists       | The Specialists                                  | [Valve Protocol](#valve)                        |
 | thps3                | Tony Hawk's Pro Skater 3                         |                                                 |

--- a/tools/generate_games_list.js
+++ b/tools/generate_games_list.js
@@ -34,7 +34,7 @@ for (const id in sortedGames) {
   if (game.options.protocol === 'valve' || game.options.protocol === 'dayz') {
     notes.push('[Valve Protocol](#valve)')
   }
-  if (game.options.protocol === 'epic' || game.options.protocol === 'asa') {
+  if (game.options.protocol === 'epic' || game.options.protocol === 'asa' || game.options.protocol === 'palworld' || game.options.protocol === 'theisleevrima') {
     notes.push('[EOS Protocol](#epic)')
   }
   if (notes.length) {


### PR DESCRIPTION
This adds EOS Notes on Palworld and The Isle Evrima.
Closes this issue: https://github.com/gamedig/node-gamedig/issues/520

—

Also, would like to have more input on a better solution for detecting this protocol on `tools/generate_games_list.js`
It's currently like this:

```
if (
  game.options.protocol === 'epic' || 
  game.options.protocol === 'asa' || 
  game.options.protocol === 'palworld' || 
  game.options.protocol === 'theisleevrima'
) {
  notes.push('[EOS Protocol](#epic)')
}
```