### PR TITLE
Updated the eco protocol to include player names and fix problems encountered when using the eco web interface behind a proxy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## To Be Released...
 ## 5.0.0-beta.3
 * Euro Truck Simulator 2 (2012) - Added support (By @podrivo #523)
-* Eco - Added support for Eco servers that require connection from a domain (By @Vito0912 #526)
+* Eco - Added support for Eco servers that require connection from a domain (By @Vito0912)
 
 ## 5.0.0-beta.2
 * Fixed support for projects using `require`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## To Be Released...
 ## 5.0.0-beta.3
 * Euro Truck Simulator 2 (2012) - Added support (By @podrivo #523)
+* Eco - Added support for Eco servers that require connection from a domain (By @Vit0912 #526)
 
 ## 5.0.0-beta.2
 * Fixed support for projects using `require`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## To Be Released...
 ## 5.0.0-beta.3
 * Euro Truck Simulator 2 (2012) - Added support (By @podrivo #523)
-* Eco - Added support for Eco servers that require connection from a domain (By @Vit0912 #526)
+* Eco - Added support for Eco servers that require connection from a domain (By @Vito0912 #526)
 
 ## 5.0.0-beta.2
 * Fixed support for projects using `require`.

--- a/protocols/eco.js
+++ b/protocols/eco.js
@@ -5,16 +5,17 @@ export default class eco extends Core {
     if (!this.options.port) this.options.port = 3001
 
     const request = await this.request({
-      url: `http://${this.options.address}:${this.options.port}/frontpage`,
+      url: `http://${this.options.host}:${this.options.port}/frontpage`,
       responseType: 'json'
     })
     const serverInfo = request.Info
 
     state.name = serverInfo.Description
-    state.numplayers = serverInfo.OnlinePlayers;
+    state.numplayers = serverInfo.OnlinePlayers
     state.maxplayers = serverInfo.TotalPlayers
     state.password = serverInfo.HasPassword
     state.gamePort = serverInfo.GamePort
+    state.players = serverInfo.OnlinePlayersNames ? serverInfo.OnlinePlayersNames.map(name => ({ name, raw: {} })) : []
     state.raw = serverInfo
   }
 }

--- a/protocols/eco.js
+++ b/protocols/eco.js
@@ -15,7 +15,7 @@ export default class eco extends Core {
     state.maxplayers = serverInfo.TotalPlayers
     state.password = serverInfo.HasPassword
     state.gamePort = serverInfo.GamePort
-    state.players = serverInfo.OnlinePlayersNames ? serverInfo.OnlinePlayersNames.map(name => ({ name, raw: {} })) : []
+    state.players = serverInfo.OnlinePlayersNames?.map(name => ({ name, raw: {} })) || []
     state.raw = serverInfo
   }
 }


### PR DESCRIPTION
This is my first pull request for this project. So if something is not aligning with the guidelines or coding styles, please give me a hint so I can change it.

The existing code for the Eco game functions correctly. However, it does not use any server protocol; instead, it accesses the web interface (just a plain http request). Many servers employ reverse proxies (or other methods) that cannot connect via the ip. A straightforward solution is to use the host name rather than the IP address. I'm uncertain why the IP address was originally used, given that this is merely a web request.

Additionally, I have included player information in the state.