### PR TITLE
fix: TeamSpeak2 server name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Farming Simulator 22 (2021) - Added support (By @Vito0912 #531)
 * Farming Simulator 19 (2018) - Added support (By @Vito0912 #531)
 * Assetto Corsa - Fixed how `state.numplayers` is set (By @podrivo #538)
+* TeamSpeak 2 - Fixed how `state.name` is set (By @podrivo #544)
 
 ## 5.0.0-beta.2
 * Fixed support for projects using `require`.

--- a/protocols/teamspeak2.js
+++ b/protocols/teamspeak2.js
@@ -18,6 +18,7 @@ export default class teamspeak2 extends Core {
           const value = equals === -1 ? '' : line.substring(equals + 1)
           state.raw[key] = value
         }
+        if ('server_name' in state.raw) state.name = state.raw.server_name
       }
 
       {


### PR DESCRIPTION
Fix how TeamSpeak 2 protocol set the `state.name`.
It closes this issue https://github.com/gamedig/node-gamedig/issues/543