### PR TITLE
feat: FS add player raw time

### DIFF
--- a/protocols/farmingsimulator.js
+++ b/protocols/farmingsimulator.js
@@ -29,6 +29,7 @@ export default class farmingsimulator extends Core {
           name: $(this).text(),
           raw: {
             isAdmin: $(this).attr('isAdmin') === 'true',
+            time: parseInt($(this).attr('uptime'), 10),
             uptime: parseInt($(this).attr('uptime'), 10)
           }
         })


### PR DESCRIPTION
Adds a 'time' field to the raw values of a player in the farming simulator protocol.
This has been sourced from #536.