### PR TITLE
Add new Palworld query implementation

### DIFF
--- a/protocols/index.js
+++ b/protocols/index.js
@@ -56,11 +56,12 @@ import beammpmaster from './beammpmaster.js'
 import beammp from './beammp.js'
 import dayz from './dayz.js'
 import theisleevrima from './theisleevrima.js'
+import palworldmaster from './palworldmaster.js'
 
 export {
-  armagetron, ase, asa, assettocorsa, battlefield, buildandshoot, cs2d, discord, doom3, eco, epic, factorio, farmingsimulator, ffow, 
+  armagetron, ase, asa, assettocorsa, battlefield, buildandshoot, cs2d, discord, doom3, eco, epic, factorio, farmingsimulator, ffow,
   fivem, gamespy1, gamespy2, gamespy3, geneshift, goldsrc, gtasao, hexen2, jc2mp, kspdmp, mafia2mp, mafia2online, minecraft,
   minecraftbedrock, minecraftvanilla, mumble, mumbleping, nadeo, openttd, palworld, quake1, quake2, quake3, rfactor, samp,
   savage2, starmade, starsiege, teamspeak2, teamspeak3, terraria, tribes1, tribes1master, unreal2, ut3, valve,
-  vcmp, ventrilo, warsow, eldewrito, beammpmaster, beammp, dayz, theisleevrima
+  vcmp, ventrilo, warsow, eldewrito, beammpmaster, beammp, dayz, theisleevrima, palworldmaster
 }

--- a/protocols/palworldmaster.js
+++ b/protocols/palworldmaster.js
@@ -1,0 +1,28 @@
+import Core from './core.js'
+
+export default class palworldmaster extends Core {
+  async run (state) {
+    let servers = []
+
+    for await (const batch of this.page()) {
+      servers = servers.concat(batch)
+    }
+
+    state.servers = servers
+  }
+
+  async * page () {
+    let hasNextPage = true
+    let currentPage = 1
+    while (hasNextPage) {
+      const request = await this.request({
+        url: `https://api.palworldgame.com/server/list?page=${currentPage + 1}`,
+        responseType: 'json'
+      })
+
+      currentPage = request.current_page
+      hasNextPage = request.is_next_page
+      yield request.server_list
+    }
+  }
+}


### PR DESCRIPTION
(This is WIP, not done)

Closes #555.

In 0.1.5, Palworld has seemingly stopped using EOS for the servers list, instead option for an in-house solution, api endpoint [here](https://api.palworldgame.com/server/list).

As of writing this message, we don't have any documentation regarding this endpoint, although we know that:
* There is also a /search endpoint (e.g. `/server/search?q=MyServer`) but it doesn't also look in the address/port fields.
* The list is paginated (fixed 500 entries per page).

Our initial solution could be:
As the user provides the ip and port, we can query for the first page of the list, look through it and return the data if present there, if not, just repeat until there is not pages left.

This is very bad to do as its an O(n) solution, where every operation is a HTTP request and takes a considerable amount of time and it comes down to luck whether your server is at the top or bottom of the list.

A potential thing that could help here is to also pass a `name` field that would be passed to the search endpoint, further narrowing down the list.

Would be glad to hear opinions on this or possible improvements/news.