### PR TITLE
feat: add `Nova-Life: Amboise` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix: BeamMP maxplayers that was displaying player count (By @dgibbs64 #551)
 * Fix: BeamMP filter servers by address, not host (By @Rephot #558)
 * Palworld - Replace old and broken protocol with the new one (#560)
+* Nova-Life: Amboise - Added support.
 
 ## 5.0.0-beta.2
 * Fixed support for projects using `require`.

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -200,6 +200,7 @@
 | nexuiz               | Nexuiz                                           |                                                 |
 | nfshp2               | Need for Speed: Hot Pursuit 2                    |                                                 |
 | nitrofamily          | Nitro Family                                     |                                                 |
+| nla                  | Nova-Life: Amboise                               | [Valve Protocol](#valve)                        |
 | nmrih                | No More Room in Hell                             | [Valve Protocol](#valve)                        |
 | nolf2asihw           | No One Lives Forever 2: A Spy in H.A.R.M.'s Way  |                                                 |
 | nucleardawn          | Nuclear Dawn                                     | [Valve Protocol](#valve)                        |
@@ -210,7 +211,7 @@
 | openarena            | OpenArena                                        |                                                 |
 | openttd              | OpenTTD                                          |                                                 |
 | painkiller           | Painkiller                                       |                                                 |
-| palworld             | Palworld                                         | [Notes](#palworld)                              |
+| palworld             | Palworld                                         |                                                 |
 | pce                  | Primal Carnage: Extinction                       | [Valve Protocol](#valve)                        |
 | pixark               | PixARK                                           | [Valve Protocol](#valve)                        |
 | postal2              | Postal 2                                         |                                                 |

--- a/lib/games.js
+++ b/lib/games.js
@@ -2026,6 +2026,14 @@ export const games = {
       old_id: 'nolf'
     }
   },
+  nla: {
+    name: 'Nova-Life: Amboise',
+    release_year: 2020,
+    options: {
+      port_query: 27015,
+      protocol: 'valve'
+    }
+  },
   nolf2asihw: {
     name: "No One Lives Forever 2: A Spy in H.A.R.M.'s Way",
     release_year: 2002,


### PR DESCRIPTION
I couldn't find the official default query port so I'll let it be the default protocol one for now.