### PR TITLE
feat: Add Minetest support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## To Be Released...
 ## 5.X.Y
-In progress?
+* Minetest - Added support for minetest utilizing official server list (By @xCausxn #572)
 
 ## 5.0.0
 * Added a new stabilized field `version` in the query response (By @podrivo #532)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## To Be Released...
 ## 5.X.Y
-* Minetest - Added support for minetest utilizing official server list (By @xCausxn #572)
+* Minetest - Added support for minetest utilizing official server list (By @xCausxn #573)
 
 ## 5.0.0
 * Added a new stabilized field `version` in the query response (By @podrivo #532)

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -179,6 +179,7 @@
 | medievalengineers    | Medieval Engineers                               | [Valve Protocol](#valve)                        |
 | mgm                  | Mumble - GT Murmur                               | [Notes](#mumble)                                |
 | minecraft            | Minecraft                                        | [Notes](#minecraft)                             |
+| minetest             | Minetest                                         |                                                 |
 | mnc                  | Monday Night Combat                              | [Valve Protocol](#valve)                        |
 | moe                  | Myth of Empires                                  | [Valve Protocol](#valve)                        |
 | moh                  | Medal of Honor                                   |                                                 |

--- a/lib/games.js
+++ b/lib/games.js
@@ -1837,6 +1837,14 @@ export const games = {
       doc_notes: 'minecraft'
     }
   },
+  minetest: {
+    name: 'Minetest',
+    release_year: 2010,
+    options: {
+      port: 30000,
+      protocol: 'minetest'
+    }
+  },
   mbe: {
     name: 'Minecraft: Bedrock Edition',
     release_year: 2011,

--- a/protocols/index.js
+++ b/protocols/index.js
@@ -28,6 +28,7 @@ import mafia2online from './mafia2online.js'
 import minecraft from './minecraft.js'
 import minecraftbedrock from './minecraftbedrock.js'
 import minecraftvanilla from './minecraftvanilla.js'
+import minetest from './minetest.js'
 import mumble from './mumble.js'
 import mumbleping from './mumbleping.js'
 import nadeo from './nadeo.js'
@@ -58,9 +59,9 @@ import dayz from './dayz.js'
 import theisleevrima from './theisleevrima.js'
 
 export {
-  armagetron, ase, asa, assettocorsa, battlefield, buildandshoot, cs2d, discord, doom3, eco, epic, factorio, farmingsimulator, ffow, 
+  armagetron, ase, asa, assettocorsa, battlefield, buildandshoot, cs2d, discord, doom3, eco, epic, factorio, farmingsimulator, ffow,
   fivem, gamespy1, gamespy2, gamespy3, geneshift, goldsrc, gtasao, hexen2, jc2mp, kspdmp, mafia2mp, mafia2online, minecraft,
-  minecraftbedrock, minecraftvanilla, mumble, mumbleping, nadeo, openttd, palworld, quake1, quake2, quake3, rfactor, samp,
+  minecraftbedrock, minecraftvanilla, minetest, mumble, mumbleping, nadeo, openttd, palworld, quake1, quake2, quake3, rfactor, samp,
   savage2, starmade, starsiege, teamspeak2, teamspeak3, terraria, tribes1, tribes1master, unreal2, ut3, valve,
   vcmp, ventrilo, warsow, eldewrito, beammpmaster, beammp, dayz, theisleevrima
 }

--- a/protocols/minetest.js
+++ b/protocols/minetest.js
@@ -1,0 +1,39 @@
+import Core from './core.js'
+
+export default class minetest extends Core {
+  constructor() {
+    super()
+    this.usedTcp = true
+  }
+
+  async run(state) {
+    const servers = await this.request({
+      url: 'https://servers.minetest.net/list',
+      responseType: 'json'
+    })
+
+    if (servers == null) {
+      throw new Error('Unable to retrieve master server list')
+    }
+
+    const serverInfo = servers.list.find(
+      (server) =>
+        server.ip === this.options.address && server.port === this.options.port
+    )
+
+    if (serverInfo == null) {
+      throw new Error('Server not found in master server list')
+    }
+
+    const players = serverInfo.clients_list || [] // the 'players' field is undefined if there are no players
+
+    state.name = serverInfo.name
+    state.password = serverInfo.password
+    state.numplayers = serverInfo.clients || players.length
+    state.maxplayers = serverInfo.clients_max
+    state.players = players.map((player) => ({ name: player, raw: {} }))
+
+    state.raw = serverInfo
+    state.version = serverInfo.version
+  }
+}


### PR DESCRIPTION
Added support for minetest, which does just use the serverlist under the hood.

Implements initial version for #571 