### PR TITLE
bug: Remove mispelling legacy entry, add backwards compat.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Minetest - Added support for minetest utilizing official server list (By @xCausxn #573)
 * Soulmask - Added support (By @xCausxn #572)
 * Restore Minecraft's favicon (#575)
-* Fix duplicate game entry for The Forest (2014), add old id for backwards compatibility (#579)
+* Fix duplicate game entry for The Forest (2014), add old id for backwards compatibility (By @xCausxn #579)
 
 ## 5.0.0
 * Added a new stabilized field `version` in the query response (By @podrivo #532)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Minetest - Added support for minetest utilizing official server list (By @xCausxn #573)
 * Soulmask - Added support (By @xCausxn #572)
 * Restore Minecraft's favicon (#575)
+* Fix duplicate game entry for The Forest (2014), add old id for backwards compatibility (#579)
 
 ## 5.0.0
 * Added a new stabilized field `version` in the query response (By @podrivo #532)

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -294,7 +294,6 @@
 | terrariatshock       | Terraria - TShock                                | [Notes](#terraria)                              |
 | tfc                  | Team Fortress Classic                            | [Valve Protocol](#valve)                        |
 | theforest            | The Forest                                       | [Valve Protocol](#valve)                        |
-| theforrest           | The Forrest                                      | [Valve Protocol](#valve)                        |
 | thefront             | The Front                                        | [Valve Protocol](#valve)                        |
 | thehidden            | The Hidden                                       | [Valve Protocol](#valve)                        |
 | theisle              | The Isle                                         | [Valve Protocol](#valve)                        |

--- a/lib/games.js
+++ b/lib/games.js
@@ -1270,18 +1270,6 @@ export const games = {
       old_id: 'fivem'
     }
   },
-  theforrest: {
-    name: 'The Forrest',
-    release_year: 2014,
-    options: {
-      port: 27015,
-      port_query_offset: 1,
-      protocol: 'valve'
-    },
-    extra: {
-      old_id: 'forrest'
-    }
-  },
   garrysmod: {
     name: "Garry's Mod",
     release_year: 2004,
@@ -2902,6 +2890,9 @@ export const games = {
       port: 27015,
       port_query_offset: 1,
       protocol: 'valve'
+    },
+    extra: {
+      old_id: 'forrest'
     }
   },
   thefront: {


### PR DESCRIPTION
Fixes #577

Added forrest as the old id for actual backwards compat. As theforrest was an error from the looks of it.