### PR TITLE
fix: assetto corsa failing all queries due to undefined

### DIFF
--- a/protocols/assettocorsa.js
+++ b/protocols/assettocorsa.js
@@ -21,7 +21,7 @@ export default class assettocorsa extends Core {
     state.password = serverInfo.pass
     state.gamePort = serverInfo.port
     state.numplayers = serverInfo.clients
-    state.version = state.raw.serverInfo.poweredBy
+    state.version = serverInfo.poweredBy
 
     state.raw.carInfo = carInfo.Cars
     state.raw.serverInfo = serverInfo


### PR DESCRIPTION
Fixes #583.

In commit [67e86d3](https://github.com/gamedig/node-gamedig/commit/67e86d3fe883c73e266a9a9e86f6fd93093304d0) I have moved an assignment that took a value from another assignment above it, resulting in all asseto corsa queries to fail because of `undefined`.

We greatly need tests to avoid such mistakes in the future.