### PR TITLE
fix: minecraft velocity name with multiple layers of color encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## To Be Released...
-## 5.0.0
-* To be made...
+## 5.X.Y
+* Fix the `name` field on Minecraft servers running Velocity with multiple layers of color encoding (#595)
 
 ## 5.1.0
 * FOUNDRY - Added support (#585)

--- a/protocols/minecraft.js
+++ b/protocols/minecraft.js
@@ -65,7 +65,21 @@ export default class minecraft extends Core {
           name = description.text
         }
         if (!name && typeof description === 'object' && description.extra) {
-          name = description.extra.map(part => part.text).join('')
+          let stack = [description];
+
+          while (stack.length > 0) {
+            let current = stack.pop();
+
+            if (current.text) {
+              name += current.text;
+            }
+
+            if (Array.isArray(current.extra)) {
+              for (let i = current.extra.length - 1; i >= 0; i--) {
+                stack.push(current.extra[i]);
+              }
+            }
+          }
         }
         state.name = name
       } catch (e) {}

--- a/protocols/minecraft.js
+++ b/protocols/minecraft.js
@@ -67,7 +67,7 @@ export default class minecraft extends Core {
         if (!name && typeof description === 'object' && description.extra) {
           let stack = [description];
 
-          while (stack.length > 0) {
+          while (stack.length) {
             let current = stack.pop();
 
             if (current.text) {

--- a/protocols/minecraft.js
+++ b/protocols/minecraft.js
@@ -75,9 +75,7 @@ export default class minecraft extends Core {
             }
 
             if (Array.isArray(current.extra)) {
-              for (let i = current.extra.length - 1; i >= 0; i--) {
-                stack.push(current.extra[i]);
-              }
+              stack.push(...current.extra.reverse());
             }
           }
         }


### PR DESCRIPTION
Related to #553: @dudekm noted that gamedig cannot extract the name of a minecraft server that runs velocity with the `description` field being color encoded on multiple layers.

Before we would loop through only the top-level `extra` objects, and now we are doing this until the last level (the change could have been easily observed with the recursive solution but I've decided to go with an iterative one).