### PR TITLE
feat: add a rules bytes return for valve protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.X.Y
 * Fix the `name` field on Minecraft servers running Velocity with multiple layers of color encoding (#595)
 * Added [Bun](https://bun.sh/) runtime support (#596)
+* Added a rules bytes return for valve protocol (By @blackwaterbread #597)
 
 ## 5.1.0
 * FOUNDRY - Added support (#585)

--- a/protocols/valve.js
+++ b/protocols/valve.js
@@ -210,12 +210,15 @@ export default class valve extends Core {
 
     const rules = {}
     state.raw.rules = rules
+    state.raw.rulesBytes = Buffer.from([])
 
     this.logger.debug('Requesting rules ...')
 
     if (this.goldsrcInfo) {
       const b = await this.udpSend('\xff\xff\xff\xffrules', b => b, () => null)
       if (b === null && !this.options.requestRulesRequired) return // timed out - the server probably has rules disabled
+
+      state.raw.rulesBytes = b
       const reader = this.reader(b)
       while (!reader.done()) {
         const key = reader.string()
@@ -225,6 +228,7 @@ export default class valve extends Core {
       const b = await this.sendPacket(0x56, null, 0x45, true)
       if (b === null && !this.options.requestRulesRequired) return // timed out - the server probably has rules disabled
 
+      state.raw.rulesBytes = b
       const reader = this.reader(b)
       const num = reader.uint(2)
       for (let i = 0; i < num; i++) {


### PR DESCRIPTION
Valve protocol seems to need an option to return rules as bytes.