### PR TITLE
Added fix for new importing style for cheerio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 ## To Be Released...
 ## 5.X.Y
+* Fixed old style of importing cheerio - https://github.com/cheeriojs/cheerio/releases/tag/v1.0.0
 * Fix the `name` field on Minecraft servers running Velocity with multiple layers of color encoding (#595)
 * Added [Bun](https://bun.sh/) runtime support (#596)
 * Added a rules bytes return for valve protocol (By @blackwaterbread #597)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 * Fix: BeamMP maxplayers that was displaying player count (By @dgibbs64 #551)
 * Fix: BeamMP filter servers by address, not host (By @Rephot #558)
 * Palworld - Replace old and broken protocol with the new one (#560)
-* Updated some wordings around the new Palworld mechanic
 
 ## 5.0.0-beta.2
 * Fixed support for projects using `require`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix: BeamMP maxplayers that was displaying player count (By @dgibbs64 #551)
 * Fix: BeamMP filter servers by address, not host (By @Rephot #558)
 * Palworld - Replace old and broken protocol with the new one (#560)
+* Updated some wordings around the new Palworld mechanic
 
 ## 5.0.0-beta.2
 * Fixed support for projects using `require`.

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -462,4 +462,4 @@ EOS does not provide players data.
 
 ### <a name="palworld"></a>Palworld
 Palworld support can be unstable, the devs mention the api is currently experimental.  
-To query Palworld servers, the `RESTAPIEnabled` setting must be `True` in the configuration file, and you need to pass the `username` (currently always `admin`) and the `adminpassword` (settings parameter) for it.
+To query Palworld servers, the `RESTAPIEnabled` setting must be `True` in the configuration file, and you need to pass the `username` (currently always `admin`) and the adminpassword (from the server config) as the password parameter.

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -462,4 +462,4 @@ EOS does not provide players data.
 
 ### <a name="palworld"></a>Palworld
 Palworld support can be unstable, the devs mention the api is currently experimental.  
-To query Palworld servers, the `RESTAPIEnabled` setting must be `True` in the configuration file, and you need to pass the `username` (currently always `admin`) and the adminpassword (from the server config) as the password parameter.
+To query Palworld servers, the `RESTAPIEnabled` setting must be `True` in the configuration file, and you need to pass the `username` (currently always `admin`) and the `adminpassword` (from the server config) as the `password` parameter.

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -462,5 +462,4 @@ EOS does not provide players data.
 
 ### <a name="palworld"></a>Palworld
 Palworld support can be unstable, the devs mention the api is currently experimental.  
-To query palworld servers, the `RESTAPIEnabled` must be `True` in the configuration file, and you need to pass
-the `username` (currently always `admin`) and `password` (settings parameter) for it.
+To query Palworld servers, the `RESTAPIEnabled` setting must be `True` in the configuration file, and you need to pass the `username` (currently always `admin`) and the `adminpassword` (settings parameter) for it.

--- a/protocols/farmingsimulator.js
+++ b/protocols/farmingsimulator.js
@@ -1,5 +1,5 @@
 import Core from './core.js'
-import cheerio from 'cheerio'
+import * as cheerio from 'cheerio'
 
 export default class farmingsimulator extends Core {
   async run (state) {


### PR DESCRIPTION
Currently you cant start apps, because node-gamedig uses cheerio, which just released a 1.0.0 release which omitted the old way of importing modules.

Source:
![image](https://github.com/user-attachments/assets/a174ecb1-be5a-420d-91ca-5e996b0a1b50)

https://github.com/cheeriojs/cheerio/issues/3986 and the fix and explainer to this - https://github.com/cheeriojs/cheerio/releases/tag/v1.0.0