### PR TITLE
fix: cheerio breaking the library on new installs and update punycode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Fix the `name` field on Minecraft servers running Velocity with multiple layers of color encoding (#595)
 * Added [Bun](https://bun.sh/) runtime support (#596)
 * Added a rules bytes return for valve protocol (By @blackwaterbread #597)
+* Lock dependencies to fix problems with cheerio's `1.0.0` release and update punycode to `2.3.1` to mitigate
+a vulnerability (#604)
 
 ## 5.1.0
 * FOUNDRY - Added support (#585)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "iconv-lite": "0.6.3",
                 "long": "5.2.3",
                 "minimist": "1.2.8",
-                "punycode": "2.3.0",
+                "punycode": "2.3.1",
                 "seek-bzip": "2.0.0",
                 "varint": "6.0.0"
             },
@@ -2836,9 +2836,9 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "node_modules/punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "engines": {
                 "node": ">=6"
             }
@@ -5438,9 +5438,9 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
         },
         "queue-microtask": {
             "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
             "version": "5.1.0",
             "license": "MIT",
             "dependencies": {
-                "cheerio": "^1.0.0-rc.12",
-                "gbxremote": "^0.2.1",
-                "got": "^13.0.0",
-                "iconv-lite": "^0.6.3",
-                "long": "^5.2.3",
-                "minimist": "^1.2.8",
-                "punycode": "^2.3.0",
-                "seek-bzip": "^2.0.0",
-                "varint": "^6.0.0"
+                "cheerio": "1.0.0-rc.12",
+                "gbxremote": "0.2.1",
+                "got": "13.0.0",
+                "iconv-lite": "0.6.3",
+                "long": "5.2.3",
+                "minimist": "1.2.8",
+                "punycode": "2.3.0",
+                "seek-bzip": "2.0.0",
+                "varint": "6.0.0"
             },
             "bin": {
                 "gamedig": "bin/gamedig.js"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "iconv-lite": "0.6.3",
         "long": "5.2.3",
         "minimist": "1.2.8",
-        "punycode": "2.3.0",
+        "punycode": "2.3.1",
         "seek-bzip": "2.0.0",
         "varint": "6.0.0"
     },

--- a/package.json
+++ b/package.json
@@ -58,15 +58,15 @@
         "README.md"
     ],
     "dependencies": {
-        "cheerio": "^1.0.0-rc.12",
-        "gbxremote": "^0.2.1",
-        "got": "^13.0.0",
-        "iconv-lite": "^0.6.3",
-        "long": "^5.2.3",
-        "minimist": "^1.2.8",
-        "punycode": "^2.3.0",
-        "seek-bzip": "^2.0.0",
-        "varint": "^6.0.0"
+        "cheerio": "1.0.0-rc.12",
+        "gbxremote": "0.2.1",
+        "got": "13.0.0",
+        "iconv-lite": "0.6.3",
+        "long": "5.2.3",
+        "minimist": "1.2.8",
+        "punycode": "2.3.0",
+        "seek-bzip": "2.0.0",
+        "varint": "6.0.0"
     },
     "devDependencies": {
         "@types/cheerio": "^0.22.31",


### PR DESCRIPTION
Closes #603.
Replacement of #602.

This PR also updates punycode to avoid a vulnerability.