### PR TITLE
fix: registerRTT would break successful queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## To Be Released...
 ## 5.X.Y
 * Added Vintage Story support via the master server (#606)
+* Fixed `registerRtt` breaking successful queries if it didn't respond in the query timeout (#610)
 * Added support for rFactor 2 (By @xCausxn #614)
 
 ## 4.3.2

--- a/protocols/core.js
+++ b/protocols/core.js
@@ -102,13 +102,11 @@ export default class Core extends EventEmitter {
 
   /** Param can be a time in ms, or a promise (which will be timed) */
   registerRtt (param) {
-    if (param.then) {
+    if (param instanceof Promise) {
       const start = Date.now()
       param.then(() => {
-        const end = Date.now()
-        const rtt = end - start
-        this.registerRtt(rtt)
-      }).catch(() => {})
+        this.registerRtt(Date.now() - start)
+      }).catch((_) => {})
     } else {
       this.logger.debug('Registered RTT: ' + param + 'ms')
       if (this.shortestRTT === 0 || param < this.shortestRTT) {
@@ -197,7 +195,7 @@ export default class Core extends EventEmitter {
         socket.on('ready', resolve)
         socket.on('close', () => reject(new Error('TCP Connection Refused')))
       })
-      await this.registerRtt(connectionPromise)
+      this.registerRtt(connectionPromise)
       connectionTimeout = Promises.createTimeout(this.options.socketTimeout, 'TCP Opening')
       await Promise.race([
         connectionPromise,

--- a/protocols/core.js
+++ b/protocols/core.js
@@ -101,20 +101,19 @@ export default class Core extends EventEmitter {
   async run (/** Results */ state) {}
 
   /** Param can be a time in ms, or a promise (which will be timed) */
-  async registerRtt (param) {
-    try {
-      if (param instanceof Promise) {
-        const start = Date.now()
-        await param
-        await this.registerRtt(Date.now() - start)
-      } else {
-        this.logger.debug(`Registered RTT: ${param}ms`)
-        if (this.shortestRTT === 0 || param < this.shortestRTT) {
-          this.shortestRTT = param
-        }
+  registerRtt (param) {
+    if (param.then) {
+      const start = Date.now()
+      param.then(() => {
+        const end = Date.now()
+        const rtt = end - start
+        this.registerRtt(rtt)
+      }).catch(() => {})
+    } else {
+      this.logger.debug('Registered RTT: ' + param + 'ms')
+      if (this.shortestRTT === 0 || param < this.shortestRTT) {
+        this.shortestRTT = param
       }
-    } catch (error) {
-      this.logger.debug(`Error in promise: ${error}`)
     }
   }
 

--- a/protocols/minecraft.js
+++ b/protocols/minecraft.js
@@ -24,9 +24,7 @@ export default class minecraft extends Core {
     const vanillaResolver = new minecraftvanilla()
     vanillaResolver.options = this.options
     vanillaResolver.udpSocket = this.udpSocket
-    promises.push((async () => {
-      try { return await vanillaResolver.runOnceSafe() } catch (e) {}
-    })())
+    promises.push(vanillaResolver)
 
     const gamespyResolver = new Gamespy3()
     gamespyResolver.options = {
@@ -34,18 +32,15 @@ export default class minecraft extends Core {
       encoding: 'utf8'
     }
     gamespyResolver.udpSocket = this.udpSocket
-    promises.push((async () => {
-      try { return await gamespyResolver.runOnceSafe() } catch (e) {}
-    })())
+    promises.push(gamespyResolver)
 
     const bedrockResolver = new minecraftbedrock()
     bedrockResolver.options = this.options
     bedrockResolver.udpSocket = this.udpSocket
-    promises.push((async () => {
-      try { return await bedrockResolver.runOnceSafe() } catch (e) {}
-    })())
+    promises.push(bedrockResolver)
 
-    const [vanillaState, gamespyState, bedrockState] = await Promise.all(promises)
+    const ranPromises = promises.map(p => p.runOnceSafe().catch(_ => undefined))
+    const [vanillaState, gamespyState, bedrockState] = await Promise.all(ranPromises)
 
     state.raw.vanilla = vanillaState
     state.raw.gamespy = gamespyState

--- a/protocols/minecraft.js
+++ b/protocols/minecraft.js
@@ -24,7 +24,9 @@ export default class minecraft extends Core {
     const vanillaResolver = new minecraftvanilla()
     vanillaResolver.options = this.options
     vanillaResolver.udpSocket = this.udpSocket
-    promises.push(vanillaResolver)
+    promises.push((async () => {
+      try { return await vanillaResolver.runOnceSafe() } catch (e) {}
+    })())
 
     const gamespyResolver = new Gamespy3()
     gamespyResolver.options = {
@@ -32,15 +34,18 @@ export default class minecraft extends Core {
       encoding: 'utf8'
     }
     gamespyResolver.udpSocket = this.udpSocket
-    promises.push(gamespyResolver)
+    promises.push((async () => {
+      try { return await gamespyResolver.runOnceSafe() } catch (e) {}
+    })())
 
     const bedrockResolver = new minecraftbedrock()
     bedrockResolver.options = this.options
     bedrockResolver.udpSocket = this.udpSocket
-    promises.push(bedrockResolver)
+    promises.push((async () => {
+      try { return await bedrockResolver.runOnceSafe() } catch (e) {}
+    })())
 
-    const ranPromises = promises.map(p => p.runOnceSafe().catch(_ => undefined))
-    const [vanillaState, gamespyState, bedrockState] = await Promise.all(ranPromises)
+    const [vanillaState, gamespyState, bedrockState] = await Promise.all(promises)
 
     state.raw.vanilla = vanillaState
     state.raw.gamespy = gamespyState


### PR DESCRIPTION
@mgrimace encountered issues by using the [Homepage](https://github.com/gethomepage/homepage/) project and adding a widget which uses `minecraft`, reported [here](https://github.com/gethomepage/homepage/discussions/3862).

After some debugging we have cloncluded that the bedrock query runs (from logs, as the target server is bedrock edition) and other fails, but the query still fails.

~~Commit [9bd3caa](https://github.com/gamedig/node-gamedig/commit/9bd3caab7b8b45d20349416419ddc36390325782) is the only a contester as why this happens, OP verified this by making the query with the version before this change (`5.0.0-beta.2`) which worked.~~ edit: it was not

Edit:
Commit [6b85c6b](https://github.com/gamedig/node-gamedig/commit/6b85c6bc0b1b3e41dcf3350499af4b21ec43da5e) ~~is also a possiblity~~ (late edit) caused successful queries to fail if `registerRtt` would take too long.

This PR pretty much reverses that commit.