### PR TITLE
ci: node remove 14, set 16 to minimum suported, add 20 and 22

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.17, 16.x, 18.x]
+        node-version: [16.20.0, 18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This PR:
* removes 14 (as we no longer support it)
* changes `16.x` to `16.20.0` (which is our minimum supported version)
* adds 20 and 22