### PR TITLE
feat: remove punycode package

### DIFF
--- a/lib/DnsResolver.js
+++ b/lib/DnsResolver.js
@@ -1,6 +1,6 @@
 import dns from 'node:dns'
 import { isIP } from 'node:net'
-import { domainToASCII } from 'url'
+import { domainToASCII } from 'node:url'
 
 export default class DnsResolver {
   /**

--- a/lib/DnsResolver.js
+++ b/lib/DnsResolver.js
@@ -1,6 +1,6 @@
 import dns from 'node:dns'
 import { isIP } from 'node:net'
-import punycode from 'punycode/punycode.js'
+import { domainToASCII } from 'url'
 
 export default class DnsResolver {
   /**
@@ -30,7 +30,11 @@ export default class DnsResolver {
       return { address: host }
     }
 
-    const asciiForm = punycode.toASCII(host)
+    const asciiForm = domainToASCII(host)
+    if (!asciiForm) {
+      throw new Error('Invalid domain')
+    }
+
     if (asciiForm !== host) {
       this.logger.debug('Encoded punycode: ' + host + ' -> ' + asciiForm)
       host = asciiForm

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
                 "iconv-lite": "0.6.3",
                 "long": "5.2.3",
                 "minimist": "1.2.8",
-                "punycode": "2.3.1",
                 "seek-bzip": "2.0.0",
                 "varint": "6.0.0"
             },
@@ -2839,6 +2838,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5440,7 +5440,8 @@
         "punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true
         },
         "queue-microtask": {
             "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
         "iconv-lite": "0.6.3",
         "long": "5.2.3",
         "minimist": "1.2.8",
-        "punycode": "2.3.1",
         "seek-bzip": "2.0.0",
         "varint": "6.0.0"
     },


### PR DESCRIPTION
Suggested by @xCausxn via Discord.
Related: #627

We used the [punycode](https://www.npmjs.com/package/punycode) package just for `toASCII`, Node already has this included via [url.domainToASCII](https://nodejs.org/api/url.html#urldomaintoasciidomain) and does the same thing.