### PR TITLE
fix: Generate games list with padded delimiter

### DIFF
--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -1,4 +1,6 @@
 ### Supported
+
+<!--- BEGIN GENERATED GAMES -->
 | GameDig Type ID      | Name                                             | See Also                                        |
 |----------------------|--------------------------------------------------|-------------------------------------------------|
 | a2oa                 | ARMA 2: Operation Arrowhead                      | [Valve Protocol](#valve)                        |
@@ -346,6 +348,7 @@
 | xpandrally           | Xpand Rally                                      |                                                 |
 | zombiemaster         | Zombie Master                                    | [Valve Protocol](#valve)                        |
 | zps                  | Zombie Panic: Source                             | [Valve Protocol](#valve)                        |
+<!--- END GENERATED GAMES -->
 
 ### Not supported (yet)
 

--- a/tools/generate_games_list.js
+++ b/tools/generate_games_list.js
@@ -34,6 +34,7 @@ const HeaderNames = {
   [HeaderType.GameName]: { Name: 'Name' },
   [HeaderType.Notes]: { Name: 'See Also' }
 }
+// defines the order of columns
 const HeaderDefinition = [
   HeaderType.ID,
   HeaderType.GameName,


### PR DESCRIPTION
Adresses the issue #607. Script will generate the same output as the current list of games.

Anchors are added back to `GAMES_IST.md`, to mark the start and end of the list (to be replaced).