### PR TITLE
feat: update Soldat protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 5.X.Y
 * Feat: Replaced `punycode` package usage with `url.domainToASCII` (#630).
 * Feat: World of Padman (2007) - Added support (#636)
-* Feat: Updated Soldat protocol (#642)
+* Feat: Update Soldat protocol (#642)
 
 ## 5.1.3
 * Fix: `Deus Ex` using the wrong protocol (#621)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.X.Y
 * Feat: Replaced `punycode` package usage with `url.domainToASCII` (#630).
 * Feat: World of Padman (2007) - Added support (#636)
+* Feat: Updated Soldat protocol (#642)
 
 ## 5.1.3
 * Fix: `Deus Ex` using the wrong protocol (#621)

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -267,7 +267,7 @@
 | sinepisodes          | SiN Episodes                                     | [Valve Protocol](#valve)                        |
 | sof                  | Soldier of Fortune                               |                                                 |
 | sof2                 | Soldier of Fortune 2                             |                                                 |
-| soldat               | Soldat                                           |                                                 |
+| soldat               | Soldat                                           | [Soldat](#soldat)                               |
 | sotf                 | Sons Of The Forest                               | [Valve Protocol](#valve)                        |
 | soulmask             | Soulmask                                         | [Valve Protocol](#valve)                        |
 | spaceengineers       | Space Engineers                                  | [Valve Protocol](#valve)                        |
@@ -490,3 +490,6 @@ EOS does not provide players data.
 ### <a name="palworld"></a>Palworld
 Palworld support can be unstable, the devs mention the api is currently experimental.  
 To query Palworld servers, the `RESTAPIEnabled` setting must be `True` in the configuration file, and you need to pass the `username` (currently always `admin`) and the `adminpassword` (from the server config) as the `password` parameter.
+
+### <a name="soldat"></a>Soldat
+Requires `Allow_Download` and `Logging` to be `1` in the server config.

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -267,7 +267,7 @@
 | sinepisodes          | SiN Episodes                                     | [Valve Protocol](#valve)                        |
 | sof                  | Soldier of Fortune                               |                                                 |
 | sof2                 | Soldier of Fortune 2                             |                                                 |
-| soldat               | Soldat                                           | [Soldat](#soldat)                               |
+| soldat               | Soldat                                           | [Notes](#soldat)                                |
 | sotf                 | Sons Of The Forest                               | [Valve Protocol](#valve)                        |
 | soulmask             | Soulmask                                         | [Valve Protocol](#valve)                        |
 | spaceengineers       | Space Engineers                                  | [Valve Protocol](#valve)                        |

--- a/lib/games.js
+++ b/lib/games.js
@@ -2651,6 +2651,9 @@ export const games = {
       port: 23073,
       port_query_offset: 10,
       protocol: 'soldat'
+    },
+    extra: {
+      doc_notes: 'soldat'
     }
   },
   sof: {

--- a/lib/games.js
+++ b/lib/games.js
@@ -2648,9 +2648,9 @@ export const games = {
     name: 'Soldat',
     release_year: 2002,
     options: {
-      port: 13073,
-      port_query_offset: 123,
-      protocol: 'ase'
+      port: 23073,
+      port_query_offset: 10,
+      protocol: 'soldat'
     }
   },
   sof: {

--- a/protocols/index.js
+++ b/protocols/index.js
@@ -62,6 +62,7 @@ import xonotic from './xonotic.js'
 import altvmp from './altvmp.js'
 import vintagestorymaster from './vintagestorymaster.js'
 import vintagestory from './vintagestory.js'
+import soldat from './soldat.js'
 
 export {
   armagetron, ase, asa, assettocorsa, battlefield, buildandshoot, cs2d, discord, doom3, eco, epic, factorio, farmingsimulator, ffow,
@@ -69,5 +70,5 @@ export {
   minecraftbedrock, minecraftvanilla, minetest, mumble, mumbleping, nadeo, openttd, palworld, quake1, quake2, quake3, rfactor, ragemp, samp,
   savage2, starmade, starsiege, teamspeak2, teamspeak3, terraria, tribes1, tribes1master, unreal2, ut3, valve,
   vcmp, ventrilo, warsow, eldewrito, beammpmaster, beammp, dayz, theisleevrima, xonotic, altvmp, vintagestorymaster,
-  vintagestory
+  vintagestory, soldat
 }

--- a/protocols/soldat.js
+++ b/protocols/soldat.js
@@ -18,6 +18,7 @@ export default class soldat extends Core {
     })
 
     const string = data.toString()
+    console.log(string)
 
     state.numplayers = extractValue(string, /Players:\s*(\d+)/, 0, Number)
     state.map = extractValue(string, /Map:\s*(.+)/, '')
@@ -38,5 +39,6 @@ export default class soldat extends Core {
     }
 
     state.raw.response = string
+    state.raw.gamemode = extractValue(string, /Gamemode:\s*(.+)/, '')
   }
 }

--- a/protocols/soldat.js
+++ b/protocols/soldat.js
@@ -18,7 +18,6 @@ export default class soldat extends Core {
     })
 
     const string = data.toString()
-    console.log(string)
 
     state.numplayers = extractValue(string, /Players:\s*(\d+)/, 0, Number)
     state.map = extractValue(string, /Map:\s*(.+)/, '')

--- a/protocols/soldat.js
+++ b/protocols/soldat.js
@@ -22,19 +22,21 @@ export default class soldat extends Core {
     state.numplayers = extractValue(string, /Players:\s*(\d+)/, 0, Number)
     state.map = extractValue(string, /Map:\s*(.+)/, '')
 
-    const lines = string.trim().split('\r\n')
+    const lines = string.trim().split('\n')
     const playersIndex = lines.findIndex(line => line.startsWith('Players list'))
 
-    for (let i = playersIndex + 1; i < lines.length - 1; i += 5) {
-      state.players.push({
-        name: lines[i].trim(),
-        raw: {
-          kills: parseInt(lines[i + 1].trim()),
-          deaths: parseInt(lines[i + 2].trim()),
-          team: parseInt(lines[i + 3].trim()),
-          ping: parseInt(lines[i + 4].trim())
-        }
-      })
+    if (playersIndex > -1) {
+      for (let i = playersIndex + 1; i < lines.length - 1; i += 5) {
+        state.players.push({
+          name: lines[i].trim(),
+          raw: {
+            kills: parseInt(lines[i + 1].trim()),
+            deaths: parseInt(lines[i + 2].trim()),
+            team: parseInt(lines[i + 3].trim()),
+            ping: parseInt(lines[i + 4].trim())
+          }
+        })
+      }
     }
 
     state.raw.response = string

--- a/protocols/soldat.js
+++ b/protocols/soldat.js
@@ -1,0 +1,42 @@
+import Core from './core.js'
+
+const extractValue = (text, regex, defaultValue, parser = (val) => val) => {
+  const match = text.match(regex)
+  return match ? parser(match[1] || defaultValue) : defaultValue
+}
+
+export default class soldat extends Core {
+  async run (state) {
+    const data = await this.withTcp(async socket => {
+      return await this.tcpSend(socket, 'STARTFILES\r\nlogs/gamestat.txt\r\nENDFILES\r\n', (data) => {
+        const asString = data.toString()
+        if (asString.endsWith('\r\n') && !asString.endsWith('ENDFILES\r\n')) {
+          return undefined
+        }
+        return data
+      })
+    })
+
+    const string = data.toString()
+
+    state.numplayers = extractValue(string, /Players:\s*(\d+)/, 0, Number)
+    state.map = extractValue(string, /Map:\s*(.+)/, '')
+
+    const lines = string.trim().split('\r\n')
+    const playersIndex = lines.findIndex(line => line.startsWith('Players list'))
+
+    for (let i = playersIndex + 1; i < lines.length - 1; i += 5) {
+      state.players.push({
+        name: lines[i].trim(),
+        raw: {
+          kills: parseInt(lines[i + 1].trim()),
+          deaths: parseInt(lines[i + 2].trim()),
+          team: parseInt(lines[i + 3].trim()),
+          ping: parseInt(lines[i + 4].trim())
+        }
+      })
+    }
+
+    state.raw.response = string
+  }
+}


### PR DESCRIPTION
Closes #174
As reported in the linked issue, the support for the `ASE` query was removed from the game "a long time ago", and the issue was made over 4 years ago, so I'd say its safe to just replace it.
Although the new game response does not provide much data, some can be extracted from the given response of:
```
STARTFILES
�logs/gamestat.txt
�In-Game Statistics
Players: 0
Map: ctf_Ash
Gamemode: Capture the Flag
Timeleft: 1:52
Team 1: 0
Team 2: 0
Team 3: 0
Team 4: 0
Players list: (name/kills/deaths/team/ping)
ENDFILES
```
To:
```
{
  "name": "",
  "map": "ctf_Ash",
  "password": false,
  "raw": {
    "response": "STARTFILES\r\n\u0000\u0000\u0000�logs/gamestat.txt\r\n\u0000\u0000\u0000�In-Game Statistics\r\nPlayers: 0\r\nMap: ctf_Ash\r\nGamemode: Capture the Flag\r\nTimeleft: 8:42\r\nTeam 1: 0\r\nTeam 2: 0\r\nTeam 3: 0\r\nTeam 4: 0\r\nPlayers list: (name/kills/deaths/team/ping)\r\nENDFILES\r\n",
    "gamemode": "Capture the Flag"
  },
  "version": "",
  "maxplayers": 0,
  "numplayers": 0,
  "players": [],
  "bots": [],
  "queryPort": 23083,
  "connect": "127.0.0.1:23083",
  "ping": 1
}
```
~~Note: players should be extracted too, I'll need to test this, therefore the draft.~~