### PR TITLE
feat: Satisfactory add lightweight query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 5.X.Y
 * Feat: Replaced `punycode` package usage with `url.domainToASCII` (#630).
 * Feat: World of Padman (2007) - Added support (#636)
-* Feat: Satisfactory - Added support (By @Smidy13 #645)
+* Feat: Satisfactory - Added support (By @Smidy13 #645, #652)
 * Feat: Update Soldat protocol (#642)
 * Feat: TOXIKK (2016) - Added support (#641)
 * Feat: Renegade X (2014) - Added support (#643)


### PR DESCRIPTION
#645 added support but the current state of the query response is not that great, it does not provide even the server name or version, this PR makes use of the lightweight query API (which is made via socket packets) to get these information.