### PR TITLE
feat(games/satisfactory): pass optional token, make http query not required

### DIFF
--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -521,8 +521,10 @@ Palworld support can be unstable, the devs mention the api is currently experime
 To query Palworld servers, the `RESTAPIEnabled` setting must be `True` in the configuration file, and you need to pass the `username` (currently always `admin`) and the `adminpassword` (from the server config) as the `password` parameter.
 
 ### <a name="satisfactory"></a>Satisfactory
-Satisfactory servers unless specified use self-signed certificates for the HTTPS API. If you are using a self-signed certificate you will need to set the `rejectUnauthorized` flag in options to `false` in order to connect.
+Satisfactory servers unless specified use self-signed certificates for the HTTPS API. If you are using proper-signed certificates you will need to set the `rejectUnauthorized` flag in options to `true` to ensure a secured query.
 For more information on setting a user certificate refer to the [Satisfactory Dedicated server/HTTPS API wiki documentation](https://satisfactory.wiki.gg/wiki/Dedicated_servers/HTTPS_API).
+
+One can also provide an authentication token via the `token` option to skip the `PasswordlessLogin` query.
 
 ### <a name="soldat"></a>Soldat
 Requires `Allow_Download` and `Logging` to be `1` in the server config.

--- a/protocols/satisfactory.js
+++ b/protocols/satisfactory.js
@@ -28,6 +28,15 @@ export default class satisfactory extends Core {
     const nameLength = response.int(2)
     state.name = response.part(nameLength).toString('utf-8')
 
+    try {
+      await this.doHttpApiQueries(state)
+    } catch (e) {
+      this.logger.debug('HTTP API query failed.')
+      this.logger.debug(e)
+    }
+  }
+
+  async doHttpApiQueries (state) {
     const headers = {
       'Content-Type': 'application/json'
     }


### PR DESCRIPTION
The original implementation of the api was done in #645, upon adding the lightweight query in #652, I queried a server which didn't allowed the `PasswordlessLogin` query to be made (`errorCode: 'passwordless_login_not_possible'`).

Looking through the docs its mentioned that:
> Third Party Applications should NOT use PasswordLogin or PasswordlessLogin, and should instead rely on the Application Tokens. 

This PR adds the possibility to pass a token via options, thus skipping the auth query.

I noticed that all servers responded to the lightweight query, which is not the case for the HTTP one, and as (currently) it does not provide basic query information such as the server name and the fact that the other one provides it, I think its better to prioritize it and just make an attempt on the HTTP one to extract more data.

Thoughts @Smidy13?

Note: this is a draft cause I didn't got to test passing the token directly.