### PR TITLE
fix: minecraft name being duplicated in the name string

### DIFF
--- a/protocols/minecraft.js
+++ b/protocols/minecraft.js
@@ -61,8 +61,6 @@ export default class minecraft extends Core {
         if (typeof description === 'string') {
           name = description
         } else if (typeof description === 'object') {
-          name = description?.text || ''
-
           const stack = [description]
 
           while (stack.length) {


### PR DESCRIPTION
Fixes #655 

It makes sense to remove this line as that object would be added in the stack array, then added to the name string again.

I have tested over 20 entries from [battlemetrics](https://www.battlemetrics.com/servers/minecraft) and found these that the bug would occur: `mc.mcskill.ru:25565`, `minecraft.mineland.net:25565` and `play.survival-games.cz:25565`, which are fixed on this branch.