### PR TITLE
fix: Use `cp` tag for accurate rust playercount

### DIFF
--- a/protocols/valve.js
+++ b/protocols/valve.js
@@ -141,6 +141,12 @@ export default class valve extends Core {
               state.maxplayers = value
             }
           }
+          if (tag.startsWith('cp')) {
+            const value = parseInt(tag.replace('cp', ''))
+            if (!isNaN(value)) {
+              state.numplayers = value
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Rust seems to report numplayers incorrectly over A2S. However the tag system exposes the correct number via the `cp` tag.

GameQ also implements this logic and we have done as well for max players.