### PR TITLE
fix: Use cp tag for accurate rust player count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 ## To Be Released...
 ## 5.X.Y
+* Fix: Use `cp` tag to get player count on Rust (By @xCausxn #663)
 
 ## 5.1.4
 * Feat: Replaced `punycode` package usage with `url.domainToASCII` (#630).

--- a/protocols/valve.js
+++ b/protocols/valve.js
@@ -141,6 +141,12 @@ export default class valve extends Core {
               state.maxplayers = value
             }
           }
+          if (tag.startsWith('cp')) {
+            const value = parseInt(tag.replace('cp', ''))
+            if (!isNaN(value)) {
+              state.numplayers = value
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Rust seems to report numplayers incorrectly over A2S. However the tag system exposes the correct number via the cp tag.

GameQ also implements this logic and we have done as well for max players.