### PR TITLE
fix: nadeo failing queries on map info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Feat: Exfil (2024) - Added support (#661)
 * Docs: Valheim numplayers being always 0 on crossplay servers (#668)
 * Fix: Palworld not respecting query output schema (#666)
+* Fix: Nadeo failing queries on map info (#667)
 
 ## 5.1.4
 * Feat: Replaced `punycode` package usage with `url.domainToASCII` (#630).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Feat: Exfil (2024) - Added support (#661)
 * Docs: Valheim numplayers being always 0 on crossplay servers (#668)
 * Fix: Palworld not respecting query output schema (#666)
-* Fix: Nadeo failing queries on map info (#667)
+* Fix: Nadeo failing queries on map info (also added version field) (#667)
 
 ## 5.1.4
 * Feat: Replaced `punycode` package usage with `url.domainToASCII` (#630).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Feat: Exfil (2024) - Added support (#661)
 * Docs: Valheim numplayers being always 0 on crossplay servers (#668)
 * Fix: Palworld not respecting query output schema (#666)
-* Fix: Nadeo failing queries on map info (also added version field) (#667)
+* Fix: Nadeo failing queries on map info (also added version field) (#667 with @Hornochs)
 
 ## 5.1.4
 * Feat: Replaced `punycode` package usage with `url.domainToASCII` (#630).

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -434,8 +434,6 @@ The server must have `xmlrpc` enabled, the port needs to be the `xmlrpc` one, no
 You must also pass the info of a user account on the server with the access level of **User** or higher
 in the options parameters as `login` and `password`.
 
-**Note**: the `map` field is not available now, see ([#634](https://github.com/gamedig/node-gamedig/issues/634)).
-
 ### <a name="gta5r"></a> Grand Theft Auto V - RAGE MP
 If you are using a FQDN for your server, you will need to set the host parameter to be this domain e.g. rage2.mydomain.com
 This is due to how the Rage MP master server works with server ids as the ip is only used in the ID if no FQDN is provided.

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -430,9 +430,11 @@ If you do not wish to run the plugin, or do not require details such as channel 
 you can use the 'mumbleping' server type instead, which uses a less accurate but more reliable solution
 
 ### <a name="nadeo"></a> Nadeo (ShootMania / TrackMania / etc)
-The server must have xmlrpc enabled, and you must pass the xmlrpc port to GameDig, not the connection port.
-You must have a user account on the server with access level User or higher.
-Pass the login into to GameDig with the additional options: login, password
+The server must have `xmlrpc` enabled, the port needs to be the `xmlrpc` one, not the connection port.  
+You must also pass the info of a user account on the server with the access level of **User** or higher
+in the options parameters as `login` and `password`.
+
+**Note**: the `map` field is not available now, see (#634).
 
 ### <a name="gta5r"></a> Grand Theft Auto V - RAGE MP
 If you are using a FQDN for your server, you will need to set the host parameter to be this domain e.g. rage2.mydomain.com

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -434,7 +434,7 @@ The server must have `xmlrpc` enabled, the port needs to be the `xmlrpc` one, no
 You must also pass the info of a user account on the server with the access level of **User** or higher
 in the options parameters as `login` and `password`.
 
-**Note**: the `map` field is not available now, see (#634).
+**Note**: the `map` field is not available now, see ([#634](https://github.com/gamedig/node-gamedig/issues/634)).
 
 ### <a name="gta5r"></a> Grand Theft Auto V - RAGE MP
 If you are using a FQDN for your server, you will need to set the host parameter to be this domain e.g. rage2.mydomain.com

--- a/protocols/nadeo.js
+++ b/protocols/nadeo.js
@@ -39,6 +39,12 @@ export default class nadeo extends Core {
         state.raw.GetCurrentGameInfo = results
       }
 
+      {
+        const results = await this.query(client, 'GetCurrentChallengeInfo')
+        state.map = this.stripColors(results.Name)
+        state.raw.GetCurrentChallengeInfo = results
+      }
+
       if (this.options.port === 5000) {
         state.gamePort = 2350
       }

--- a/protocols/nadeo.js
+++ b/protocols/nadeo.js
@@ -19,9 +19,9 @@ export default class nadeo extends Core {
       }
 
       {
-        const results = await this.query(client, 'GetVersion')
-        state.version = results.Version
-        state.raw.GetVersion = results
+        const results = await this.query(client, 'GetCurrentChallengeInfo')
+        state.map = this.stripColors(results.Name)
+        state.raw.GetCurrentChallengeInfo = results
       }
 
       {
@@ -40,9 +40,9 @@ export default class nadeo extends Core {
       }
 
       {
-        const results = await this.query(client, 'GetCurrentChallengeInfo')
-        state.map = this.stripColors(results.Name)
-        state.raw.GetCurrentChallengeInfo = results
+        const results = await this.query(client, 'GetVersion')
+        state.version = results.Version
+        state.raw.GetVersion = results
       }
 
       if (this.options.port === 5000) {


### PR DESCRIPTION
Closes #634 
~~Servers of Trackmania Nations Forever seem to not respond on `GetCurrentMapInfo` and `GetNextMapInfo` anymore, and I couldn't find a suitable replacement, so this fix removes the assignment of the `map` value (and some next map info in the raw object), made a docs note about this.~~
@Hornochs found a method which contains the map name, merged into this branch by #669

The `version` field is now assigned and the raw object contains more fields that werent added beforehand.

Will merge when I'll also get to test the other games that use the protocol: `Shootmania` and `Trackmania 2`.