### PR TITLE
feat(gta5f): wrap query of players in a catch

### DIFF
--- a/protocols/fivem.js
+++ b/protocols/fivem.js
@@ -20,7 +20,7 @@ export default class fivem extends quake2 {
       if ('version' in state.raw.info) state.version = state.raw.info.version
     }
 
-    {
+    try {
       const json = await this.request({
         url: 'http://' + this.options.address + ':' + this.options.port + '/players.json',
         responseType: 'json'
@@ -29,6 +29,6 @@ export default class fivem extends quake2 {
       for (const player of json) {
         state.players.push({ name: player.name, ping: player.ping })
       }
-    }
+    } catch (_) {}
   }
 }


### PR DESCRIPTION
By default, FiveM do not provide players data [by default anymore](https://forum.cfx.re/t/warning-modified-players-json-endpoint/5286569/4), to fix this, the `sv_exposePlayerIdentifiersInHttpEndpoint` convar must be `1`.

This issue has been found on the Discord server, fix and more context by @xCausxn.