### PR TITLE
docs(counterstrike2): does not provide player names, note workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.X.Y
 * Docs: Arma Reforger query setup note (#670, thanks @xCausxn)
 * Fix: Grand Theft Auto V - FiveM wrap the players query in a try block as it doesn't provide the data by default anymore (#674, thanks @xCausxn)
+* Docs: Counter-Strike 2 does not provide players names, note this and a plugin workaround (#675).
 
 ## 5.2.0
 * Fix: Palworld not respecting query output players schema (#666)

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -79,7 +79,7 @@
 | corekeeper           | Core Keeper                                      | [Valve Protocol](#valve)                         |
 | counterstrike15      | Counter-Strike 1.5                               |                                                  |
 | counterstrike16      | Counter-Strike 1.6                               | [Valve Protocol](#valve)                         |
-| counterstrike2       | Counter-Strike 2                                 | [Valve Protocol](#valve)                         |
+| counterstrike2       | Counter-Strike 2                                 | [Notes](#cs2), [Valve Protocol](#valve)          |
 | crce                 | Cross Racing Championship Extreme                |                                                  |
 | creativerse          | Creativerse                                      | [Valve Protocol](#valve)                         |
 | crysis               | Crysis                                           |                                                  |
@@ -538,3 +538,6 @@ Requires `Allow_Download` and `Logging` to be `1` in the server config.
 
 ### <a name="gta5f"></a>Grand Theft Auto V - FiveM
 Requires the `sv_exposePlayerIdentifiersInHttpEndpoint` convar to be `1` for the query to return players' data.
+
+### <a name="cs2"></a>Counter-Strike 2
+Does not provide players names, using a plugin like this [one](https://github.com/Source2ZE/ServerListPlayersFix) makes the query to return them.

--- a/lib/games.js
+++ b/lib/games.js
@@ -777,7 +777,8 @@ export const games = {
       protocol: 'valve'
     },
     extra: {
-      old_id: 'cs2'
+      old_id: 'cs2',
+      doc_notes: 'cs2'
     }
   },
   creativerse: {


### PR DESCRIPTION
Closes #673, #387 is related.

In #387 we found some server that did provide players data, it turns out these servers were using plugin workarounds which we found in #673. Unfortunately there is no fix for this but to use such a plugin, this PR documents this.