### PR TITLE
Re-add players to mumbleping protocol state

### DIFF
--- a/protocols/mumbleping.js
+++ b/protocols/mumbleping.js
@@ -19,6 +19,7 @@ export default class mumbleping extends Core {
     state.version = state.raw.versionMajor + '.' + state.raw.versionMinor + '.' + state.raw.versionPatch
     reader.skip(8)
     state.numplayers = reader.uint(4)
+    state.players = state.numplayers
     state.maxplayers = reader.uint(4)
     state.raw.allowedbandwidth = reader.uint(4)
   }

--- a/protocols/mumbleping.js
+++ b/protocols/mumbleping.js
@@ -19,7 +19,7 @@ export default class mumbleping extends Core {
     state.version = state.raw.versionMajor + '.' + state.raw.versionMinor + '.' + state.raw.versionPatch
     reader.skip(8)
     state.numplayers = reader.uint(4)
-    state.players = state.numplayers
+    state.players.setNum(state.numplayers)
     state.maxplayers = reader.uint(4)
     state.raw.allowedbandwidth = reader.uint(4)
   }


### PR DESCRIPTION
# Issue

mumbleping protocol removing `state.players` breaks other integrations.

# Details

1. `state.players` was replaced by `state.numplayers` in mumbleping. https://github.com/gamedig/node-gamedig/commit/da7a4a6334f398f8cdc703565b36913887d2393b#diff-8b4314cad31b02decc96b4be3c3d50f04c0177bf6c773000c854c2e0f559c0a1
2. Many current gamedig protocols still use `state.players`: https://github.com/search?q=repo%3Agamedig%2Fnode-gamedig%20state.players&type=code
3. The popular service [Homepage](https://gethomepage.dev/) requests `players` and not `numplayers`: https://github.com/gethomepage/homepage/blob/fea4b27bb4f5501301b568550c2689d3d031fd13/src/widgets/gamedig/proxy.js#L27

# Possible solutions
1. Unify all protocols to use `numplayers`, and inform everything that uses gamedig to update to use `numplayers` rather than `players`...
2. Store `state.numplayers` value in `state.players` too (as an int).

# This is solution 2.

I am not a node expert, but have gone with `setNum` based on the link in Details 1. Please check if this works.

Fixes https://github.com/gamedig/node-gamedig/issues/677