### PR TITLE
ci: run games_list on GAMES_LIST.md change

### DIFF
--- a/.github/workflows/games_list.yml
+++ b/.github/workflows/games_list.yml
@@ -4,10 +4,12 @@ on:
   push:
     paths:
       - "lib/games.js"
+      - "GAMES_LIST.md"
       - ".github/workflows/games_list.yml" # This action
   pull_request:
     paths:
       - "lib/games.js"
+      - "GAMES_LIST.md"
       - ".github/workflows/games_list.yml" # This action
   workflow_dispatch:
 


### PR DESCRIPTION
This CI wouldn't run on #683 because neither of the trigger files have been changed but the `GAMES_LIST.md` file did, so we'd add it to the trigger list to make sure any alternations of it are properly set.