### PR TITLE
chore: update long and fast-xml-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix: Terraria - add missing supported maxplayers field and raw field (By @GoodDays13 #686)
 * Chore: Replace cheerio with fast-xml-parser (By @xCausxn #683)
 * Fix: Build and Shoot protocol using the new json status server (By @xCausxn #683)
+* Chore: Update `long` from `5.2.3` to `5.3.2`
 
 ## 5.2.0
 * Fix: Palworld not respecting query output players schema (#666)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Fix: Terraria - add missing supported maxplayers field and raw field (By @GoodDays13 #686)
 * Chore: Replace cheerio with fast-xml-parser (By @xCausxn #683)
 * Fix: Build and Shoot protocol using the new json status server (By @xCausxn #683)
-* Chore: Update `long` from `5.2.3` to `5.3.2`
+* Chore: Update `long` from `5.2.3` to `5.3.2` (#687)
 
 ## 5.2.0
 * Fix: Palworld not respecting query output players schema (#666)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
             "version": "5.2.0",
             "license": "MIT",
             "dependencies": {
-                "fast-xml-parser": "5.0.9",
+                "fast-xml-parser": "5.2.1",
                 "gbxremote": "0.2.1",
                 "got": "13.0.0",
                 "iconv-lite": "0.6.3",
-                "long": "5.2.3",
+                "long": "5.3.2",
                 "minimist": "1.2.8",
                 "seek-bzip": "2.0.0",
                 "varint": "6.0.0"
@@ -1594,9 +1594,9 @@
             "dev": true
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.0.9.tgz",
-            "integrity": "sha512-2mBwCiuW3ycKQQ6SOesSB8WeF+fIGb6I/GG5vU5/XEptwFFhp9PE8b9O7fbs2dpq9fXn4ULR3UsfydNUCntf5A==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.1.tgz",
+            "integrity": "sha512-Kqq/ewnRACQ20e0BlQ5KqHRYWRBp7yv+jttK4Yj2yY+2ldgCoxJkrP1NHUhjypsJ+eQXlGJ/jebM3wa60s1rbQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2374,9 +2374,9 @@
             "dev": true
         },
         "node_modules/long": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-            "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
         },
         "node_modules/lowercase-keys": {
             "version": "3.0.0",
@@ -4393,9 +4393,9 @@
             "dev": true
         },
         "fast-xml-parser": {
-            "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.0.9.tgz",
-            "integrity": "sha512-2mBwCiuW3ycKQQ6SOesSB8WeF+fIGb6I/GG5vU5/XEptwFFhp9PE8b9O7fbs2dpq9fXn4ULR3UsfydNUCntf5A==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.1.tgz",
+            "integrity": "sha512-Kqq/ewnRACQ20e0BlQ5KqHRYWRBp7yv+jttK4Yj2yY+2ldgCoxJkrP1NHUhjypsJ+eQXlGJ/jebM3wa60s1rbQ==",
             "requires": {
                 "strnum": "^2.0.5"
             }
@@ -4948,9 +4948,9 @@
             "dev": true
         },
         "long": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-            "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
         },
         "lowercase-keys": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
         "README.md"
     ],
     "dependencies": {
-        "fast-xml-parser": "5.0.9",
+        "fast-xml-parser": "5.2.1",
         "gbxremote": "0.2.1",
         "got": "13.0.0",
         "iconv-lite": "0.6.3",
-        "long": "5.2.3",
+        "long": "5.3.2",
         "minimist": "1.2.8",
         "seek-bzip": "2.0.0",
         "varint": "6.0.0"


### PR DESCRIPTION
long should be noted in the changelog, fast-xml-parser not as its been added in this release and already mentioned in the doc