### PR TITLE
feat(protocol/brokeprotocol): replace explicit got usage

### DIFF
--- a/protocols/brokeprotocolmaster.js
+++ b/protocols/brokeprotocolmaster.js
@@ -128,7 +128,8 @@ export default class brokeprotocolmaster extends Core {
     try {
       await this.request({
         url: this.backendApiUriCheck,
-        method: 'HEAD'
+        method: 'HEAD',
+        retry: { limit: 0 } // TODO: #650 remove this
       })
 
       return true

--- a/protocols/brokeprotocolmaster.js
+++ b/protocols/brokeprotocolmaster.js
@@ -126,11 +126,12 @@ export default class brokeprotocolmaster extends Core {
    */
   async checkApi () {
     try {
-      const response = await this.rawRequest({
+      await this.request({
         url: this.backendApiUriCheck,
         method: 'HEAD'
       })
-      return !!response?.ok
+
+      return true
     } catch (err) {
       // ignore error message
     }

--- a/protocols/brokeprotocolmaster.js
+++ b/protocols/brokeprotocolmaster.js
@@ -122,7 +122,7 @@ export default class brokeprotocolmaster extends Core {
 
   /**
    * Checks if the API is available
-   * @returns a list of servers as raw data
+   * @returns a boolean representing api availability
    */
   async checkApi () {
     try {

--- a/protocols/brokeprotocolmaster.js
+++ b/protocols/brokeprotocolmaster.js
@@ -1,5 +1,4 @@
 import Core from './core.js'
-import got from 'got'
 // import Ajv from 'ajv'
 // const ajv = new Ajv()
 
@@ -127,10 +126,9 @@ export default class brokeprotocolmaster extends Core {
    */
   async checkApi () {
     try {
-      const response = await got(this.backendApiUriCheck, {
-        method: 'HEAD',
-        timeout: { request: 2000 },
-        retry: { limit: 0 }
+      const response = await this.rawRequest({
+        url: this.backendApiUriCheck,
+        method: 'HEAD'
       })
       return !!response?.ok
     } catch (err) {

--- a/protocols/core.js
+++ b/protocols/core.js
@@ -310,13 +310,6 @@ export default class Core extends EventEmitter {
   async request (params) {
     await this.tcpPing()
 
-    const response = await this.rawRequest(params)
-    return response.body
-  }
-
-  async rawRequest (params) {
-    await this.tcpPing()
-
     let requestPromise
     try {
       requestPromise = got({
@@ -333,7 +326,7 @@ export default class Core extends EventEmitter {
       })
       const wrappedPromise = requestPromise.then(response => {
         if (response.statusCode !== 200) throw new Error('Bad status code: ' + response.statusCode)
-        return response
+        return response.body
       })
       return await Promise.race([wrappedPromise, this.abortedPromise])
     } finally {

--- a/protocols/core.js
+++ b/protocols/core.js
@@ -310,6 +310,13 @@ export default class Core extends EventEmitter {
   async request (params) {
     await this.tcpPing()
 
+    const response = await this.rawRequest(params)
+    return response.body
+  }
+
+  async rawRequest (params) {
+    await this.tcpPing()
+
     let requestPromise
     try {
       requestPromise = got({
@@ -326,7 +333,7 @@ export default class Core extends EventEmitter {
       })
       const wrappedPromise = requestPromise.then(response => {
         if (response.statusCode !== 200) throw new Error('Bad status code: ' + response.statusCode)
-        return response.body
+        return response
       })
       return await Promise.race([wrappedPromise, this.abortedPromise])
     } finally {


### PR DESCRIPTION
This technically adds 2 regressions on this particular protocol:

1. The api check call now uses the state timeout, this could be justified as we'd maybe like to customize it/inline that request with the other's behaviour.
2. Before this, got's `ok` was used, which represents if the request was 'successfully' made, which now consists just checking if the `statusCode` is 200, the other did multiple checks, but I'd say this is fine as this was the only usecase of it in the whole project.