### PR TITLE
fix(core/http): remove got internal retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 ## To Be Released...
 ## 5.X.Y
+* Fix: HTTP requests would end up making more retries than needed due to got's internal retry mechanism (#690)
 
 ## 5.3.0
 * Docs: Arma Reforger query setup note (#670, thanks @xCausxn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## To Be Released...
 ## 5.X.Y
-* Fix: HTTP requests would end up making more retries than needed due to got's internal retry mechanism (#690)
+* Fix: HTTP requests would end up making more retries than needed due to got's internal retry mechanism (#690, thanks @RattleSN4K3)
 
 ## 5.3.0
 * Docs: Arma Reforger query setup note (#670, thanks @xCausxn)

--- a/protocols/brokeprotocolmaster.js
+++ b/protocols/brokeprotocolmaster.js
@@ -128,8 +128,7 @@ export default class brokeprotocolmaster extends Core {
     try {
       await this.request({
         url: this.backendApiUriCheck,
-        method: 'HEAD',
-        retry: { limit: 0 } // TODO: #650 remove this
+        method: 'HEAD'
       })
 
       return true

--- a/protocols/core.js
+++ b/protocols/core.js
@@ -316,6 +316,9 @@ export default class Core extends EventEmitter {
         ...params,
         timeout: {
           request: this.options.socketTimeout
+        },
+        retry: {
+          limit: 0
         }
       })
       this.logger.debug(log => {


### PR DESCRIPTION
Closes #650.

We don't make use of the got's internal retry mechanism as we have our own, this would end up making additional unwanted retries.