### PR TITLE
meta: add pr templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,29 @@
+---
+name: Feature
+about: Add something new and hopefully useful
+title: 'feat: add this game'
+labels: enhancement
+assignees: ''
+
+---
+
+**Describe the changes**
+A clear and concise summary of the changes.
+
+**Screenshots or Data**
+If applicable, add screenshots/data to help explain the changes.
+<details>
+This contains lots and lots of logs.
+```
+How to do a collapsible section:
+<details>
+This is hidden until it is not!
+</details>
+```
+</details>
+
+**Additional context**
+Add any other context about the changes here, for example:
+* 'Closes issue #T'
+* 'Could be related to #F'
+* 'This is similar to the #Two problem discussed on the Discord server.'

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -2,7 +2,7 @@
 name: Feature
 about: Add something new and hopefully useful
 title: 'feat: add this game'
-labels: enhancement
+labels: feature
 assignees: ''
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -11,6 +11,7 @@ assignees: ''
 **Describe the changes**
 [ ] I have added a line in the [CHANGELOG.md](https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md) file.
 <!-- (example): `* Feat: Add a 10th character (By @you, #PR_NUMBER)` -->
+<!-- Note: mentioning yourself is not necessary, everything else is! -->
 
 A clear and concise summary of the changes.
 

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -9,7 +9,7 @@ assignees: ''
 
 <!-- This section must be completed! -->
 **Describe the changes**
-[ ] I have added a line in the [CHANGELOG.md](https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md) file.
+- [ ] I have added a line in the [CHANGELOG.md](https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md) file.
 <!-- (example): `* Feat: Add a 10th character (By @you, #PR_NUMBER)` -->
 <!-- Note: mentioning yourself is not necessary, everything else is! -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -7,7 +7,11 @@ assignees: ''
 
 ---
 
+<!-- This section must be completed! -->
 **Describe the changes**
+[ ] I have added a line in the [CHANGELOG.md](https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md) file.
+<!-- (example): `* Feat: Add a 10th character (By @you, #PR_NUMBER)` -->
+
 A clear and concise summary of the changes.
 
 **Screenshots or Data**

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -29,6 +29,6 @@ This is hidden until it is not!
 
 **Additional context**
 Add any other context about the changes here, for example:
-* 'Closes issue #T'
-* 'Could be related to #F'
-* 'This is similar to the #Two problem discussed on the Discord server.'
+* 'Closes issue #T, lore-related to issue #F, mentioned in pr #Two'
+* 'To validate the changes, one can test on this address: 127.255.0.256'
+* 'I couldn't find any live servers to validate these changes, here are the docs on how to start a local server: www.google.com'

--- a/.github/PULL_REQUEST_TEMPLATE/fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix.md
@@ -7,7 +7,11 @@ assignees: ''
 
 ---
 
+<!-- This section must be completed! -->
 **Describe the changes**
+[ ] I have added a line in the [CHANGELOG.md](https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md) file.
+<!-- (example): `* Fix: The word engineer has 3 e's in it (By @you, #PR_NUMBER)` -->
+
 A clear and concise summary of the changes.
 
 **Screenshots or Data**

--- a/.github/PULL_REQUEST_TEMPLATE/fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix.md
@@ -9,7 +9,7 @@ assignees: ''
 
 <!-- This section must be completed! -->
 **Describe the changes**
-[ ] I have added a line in the [CHANGELOG.md](https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md) file.
+- [ ] I have added a line in the [CHANGELOG.md](https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md) file.
 <!-- (example): `* Fix: The word engineer has 3 e's in it (By @you, #PR_NUMBER)` -->
 <!-- Note: mentioning yourself is not necessary, everything else is! -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix.md
@@ -11,6 +11,7 @@ assignees: ''
 **Describe the changes**
 [ ] I have added a line in the [CHANGELOG.md](https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md) file.
 <!-- (example): `* Fix: The word engineer has 3 e's in it (By @you, #PR_NUMBER)` -->
+<!-- Note: mentioning yourself is not necessary, everything else is! -->
 
 A clear and concise summary of the changes.
 

--- a/.github/PULL_REQUEST_TEMPLATE/fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix.md
@@ -1,0 +1,29 @@
+---
+name: Fix
+about: Change something broken to make it not broken anymore
+title: 'fix: 1 === 1 is false'
+labels: bug
+assignees: ''
+
+---
+
+**Describe the changes**
+A clear and concise summary of the changes.
+
+**Screenshots or Data**
+If applicable, add screenshots/data to help explain the changes.
+<details>
+This contains lots and lots of logs.
+```
+How to do a collapsible section:
+<details>
+This is hidden until it is not!
+</details>
+```
+</details>
+
+**Additional context**
+Add any other context about the changes here, for example:
+* 'Closes issue #T'
+* 'Could be related to #F'
+* 'This is similar to the #Two problem discussed on the Discord server.'

--- a/.github/PULL_REQUEST_TEMPLATE/fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix.md
@@ -29,6 +29,6 @@ This is hidden until it is not!
 
 **Additional context**
 Add any other context about the changes here, for example:
-* 'Closes issue #T'
-* 'Could be related to #F'
-* 'This is similar to the #Two problem discussed on the Discord server.'
+* 'Closes issue #T, lore-related to issue #F, mentioned in pr #Two'
+* 'To validate the changes, one can test on this address: 127.255.0.256'
+* 'I couldn't find any live servers to validate these changes, here are the docs on how to start a local server: www.google.com'


### PR DESCRIPTION
**Describe the changes**
- [ ] I have added a line in the [CHANGELOG.md](https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md) file.

This particular PR does not need mentioning in the file as its just something related to github and nothing else relating the project (like docs for example, which needs to be mentioned).

Adding templates makes pull requests more concise and helps with standardized procedures of doing so.

**Additional context**
Closes #552.
Template inspired by the existing issue templates.

@xCausxn these are visible only after merging this issue, if you got any suggestions please comment here and I'll do a follow up.
