### PR TITLE
fix(core): throwing in tcpSend onData callback would crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Feat: 7 Days to Die get more optional Telnet data via an option (#693)
 * Feat: Update OpenTTD (By @mwkaicz #695)
 * Fix: Skip non-response packets in protocol-battlefield (By @cetteup #704)
+* Fix: throwing in tcpSend onData callback would crash gamedig (#705, thanks @cetteup)
 
 ## 5.3.0
 * Docs: Arma Reforger query setup note (#670, thanks @xCausxn)

--- a/protocols/core.js
+++ b/protocols/core.js
@@ -222,11 +222,16 @@ export default class Core extends EventEmitter {
   async tcpSend (socket, buffer, ondata) {
     let timeout
     try {
-      const promise = new Promise((resolve, _reject) => {
+      const promise = new Promise((resolve, reject) => {
         let received = Buffer.from([])
         const onData = (data) => {
           received = Buffer.concat([received, data])
-          const result = ondata(received)
+          let result
+          try {
+            result = ondata(received)
+          } catch (e) {
+            reject(e)
+          }
           if (result !== undefined) {
             socket.removeListener('data', onData)
             resolve(result)


### PR DESCRIPTION
Closes #701
This was bound to happen as in:
https://github.com/gamedig/node-gamedig/blob/d3461ffb6167a49518a806b4de782ec438252c7c/protocols/battlefield.js#L115
we would throw inside a callback which wasn't caught.

This is not the case for udpSend as there its already handled.