### PR TITLE
fix(game/farmingsimulator): handle possible missing mod attribute

### DIFF
--- a/protocols/farmingsimulator.js
+++ b/protocols/farmingsimulator.js
@@ -50,7 +50,7 @@ export default class farmingsimulator extends Core {
       mods: []
     }
 
-    const mods = serverInfo.Mods.Mod
+    const mods = serverInfo?.Mods?.Mod || [];
 
     for (const mod of mods) {
       if (mod['@_name'] == null) { continue }


### PR DESCRIPTION
Fixed Problem with vanilla servers. when no mods are activated on the server the mod part is missing in the xml. (https://github.com/gamedig/node-gamedig/issues/722)