### PR TITLE
fix: corrected star trek elite force 2 name

### DIFF
--- a/lib/games.js
+++ b/lib/games.js
@@ -2812,8 +2812,8 @@ export const games = {
       protocol: 'quake3'
     }
   },
-  stvef2: {
-    name: 'Star Trek: Voyager - Elite Force 2',
+  stef2: {
+    name: 'Star Trek: Elite Force II',
     release_year: 2003,
     options: {
       port_query: 29253,


### PR DESCRIPTION
I noticed that Star Trek: Elite Force II is named incorrectly, this PR corrects the name.

Star Trek: Voyager - Elite Force 2 > Star Trek: Elite Force II

https://en.wikipedia.org/wiki/Star_Trek:_Elite_Force_II
