### PR TITLE
feat(games): add Clive Barker's Undying to game list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix: BeamMP would not match on given port (#730)
 * Fix: version field would sometimes be a Number type (#735)
 * Feat: Squad - Replace Valve protocol with EOS protocol (By @k3ithos #731)
+* Feat: Clive Barker's Undying - Added support (By @dgibbs64 #733)
 
 ## 5.3.1
 * Fix: HTTP requests would end up making more retries than needed due to got's internal retry mechanism (#690, thanks @RattleSN4K3)

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -57,6 +57,7 @@
 | c2d                  | CS2D                                             |                                                  |
 | c3db                 | Commandos 3: Destination Berlin                  |                                                  |
 | cacr                 | Command and Conquer: Renegade                    |                                                  |
+| cbu                  | Clive Barker's Undying                           |                                                  |
 | chaser               | Chaser                                           |                                                  |
 | chrome               | Chrome                                           |                                                  |
 | cmw                  | Chivalry: Medieval Warfare                       | [Valve Protocol](#valve)                         |

--- a/lib/games.js
+++ b/lib/games.js
@@ -510,6 +510,15 @@ export const games = {
       doc_notes: 'aosc-buildandshoot'
     }
   },
+  cbu: {
+    name: "Clive Barker's Undying",
+    release_year: 2002,
+    options: {
+      port: 7777,
+      port_query_offset: 1,
+      protocol: 'gamespy1'
+    },
+  },  
   cod: {
     name: 'Call of Duty',
     release_year: 2003,

--- a/lib/games.js
+++ b/lib/games.js
@@ -517,8 +517,8 @@ export const games = {
       port: 7777,
       port_query_offset: 1,
       protocol: 'gamespy1'
-    },
-  },  
+    }
+  },
   cod: {
     name: 'Call of Duty',
     release_year: 2003,


### PR DESCRIPTION
* Added new game entry for "Clive Barker's Undying"
* Release year set to 2002
* Configured options with port 7777 and protocol 'gamespy1'

https://en.wikipedia.org/wiki/Clive_Barker%27s_Undying

test server 202.61.207.59:7777