### PR TITLE
fix(core): reassign version to make sure the type is string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Feat: SCP: Secret Laboratory (2020) - Added support (#715, thanks @Draakoor)
 * Fix: Farming Simulator handle possible missing mod attribute (By @yellowfromseegg #723)
 * Fix: BeamMP would not match on given port (#730)
+* Fix: version field would sometimes be a Number (#735)
 
 ## 5.3.1
 * Fix: HTTP requests would end up making more retries than needed due to got's internal retry mechanism (#690, thanks @RattleSN4K3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Feat: SCP: Secret Laboratory (2020) - Added support (#715, thanks @Draakoor)
 * Fix: Farming Simulator handle possible missing mod attribute (By @yellowfromseegg #723)
 * Fix: BeamMP would not match on given port (#730)
-* Fix: version field would sometimes be a Number (#735)
+* Fix: version field would sometimes be a Number type (#735)
 
 ## 5.3.1
 * Fix: HTTP requests would end up making more retries than needed due to got's internal retry mechanism (#690, thanks @RattleSN4K3)

--- a/protocols/core.js
+++ b/protocols/core.js
@@ -89,6 +89,7 @@ export default class Core extends EventEmitter {
     state.name = (state.name || '').trim()
     state.connect = state.connect || `${state.gameHost || options.host || options.address}:${state.gamePort || options.port}`
     state.ping = this.shortestRTT
+    state.version = String(state.version) // #734 - we should eventually do this for the entire query schema
 
     delete state.gameHost
     delete state.gamePort


### PR DESCRIPTION
Related #734, it'll be a good thing to eventually do this for the entire schema to ensure typing.