### PR TITLE
ci(games_list): add the generation script to triggers

### DIFF
--- a/.github/workflows/games_list.yml
+++ b/.github/workflows/games_list.yml
@@ -5,11 +5,13 @@ on:
     paths:
       - "lib/games.js"
       - "GAMES_LIST.md"
+      - "tools/generate_games_list.js"
       - ".github/workflows/games_list.yml" # This action
   pull_request:
     paths:
       - "lib/games.js"
       - "GAMES_LIST.md"
+      - "tools/generate_games_list.js"
       - ".github/workflows/games_list.yml" # This action
   workflow_dispatch:
 


### PR DESCRIPTION
For reasoning, in #731 CI failed cause we forgot to add the game name in the blanket inclusion list in the tools script, this was fixed in https://github.com/gamedig/node-gamedig/commit/f715b7fe5cf0b13fdea6a6b33d51e056a6963c2b but CI check didnt trigger for it, so we'll add it as this could affect the outcome of the generated content.