### PR TITLE
feat: enhance host and port parsing to support IPv6 addresses

### DIFF
--- a/bin/gamedig.js
+++ b/bin/gamedig.js
@@ -24,13 +24,20 @@ for (const key of Object.keys(argv)) {
   options[key] = value
 }
 
-// Separate host and port
+// Separate host and port, supporting IPv6 addresses (RFC 3986)
 if (argv._.length >= 1) {
-  const target = argv._[0]
-  const split = target.split(':')
-  options.host = split[0]
-  if (split.length > 1) {
-    options.port = split[1]
+  const target = String(argv._[0])
+  const bracketed = target.match(/^\[(.+)\](?::(.+))?$/)
+  if (bracketed) {
+    // Bracketed IPv6, e.g. [2001:db8::1]:27015 or [2001:db8::1]
+    options.host = bracketed[1]
+    if (bracketed[2]) options.port = bracketed[2]
+  } else if (target.split(':').length === 2) {
+    // Exactly one colon: host:port or ipv4:port
+    [options.host, options.port] = target.split(':')
+  } else {
+    // No port, or a bare (unbracketed) IPv6 address
+    options.host = target
   }
 }
 


### PR DESCRIPTION
Closes #769

## Problem

The CLI split the target on every colon (`target.split(':')`), so IPv6 addresses broke — the first internal colon was treated as the host/port separator, even in bracketed form (`[2001:db8::1]:27015`):

```
$ gamedig --type minecraft [2409:8a55:...:3ed1]:25565 --debug
  host: '[2409'
Q#0 Query failed with error Error: Invalid domain
```

## Fix

Reworked host/port parsing in `bin/gamedig.js`. Besides the bracketed form, colon count disambiguates: exactly one colon means `host:port`; zero or 2+ means the whole string is the host (hostnames, IPv4, unbracketed IPv6).

```js
if (argv._.length >= 1) {
  const target = String(argv._[0])
  const bracketed = target.match(/^\[(.+)\](?::(.+))?$/)
  if (bracketed) {
    options.host = bracketed[1]
    if (bracketed[2]) options.port = bracketed[2]
  } else if (target.split(':').length === 2) {
    [options.host, options.port] = target.split(':')
  } else {
    options.host = target
  }
}
```

No downstream changes needed: `DnsResolver.resolve()` already short-circuits valid IPs via `isIP(host)`.

## Compatibility

Hostnames, IPv4, and `host:port` parse identically to before — only the broken IPv6 cases change. `String(...)` guards against Minimist coercing a numeric-only host to a number.

## Testing

- Verified the issue repro now parses correctly and reaches a TCP connection attempt.
- Diffed old vs. new parsing across all input types — identical for valid existing inputs.
- `npm run lint:check` passes.