### PR TITLE
feat: add appId option check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Feat: The Cenozoic Era - Added support (#768)
 * Feat: VEIN - Added support (#768)
 * Feat: Mindustry - Added support (#768)
+* Fix: Starbound - report correct appId (211820) via a new optional valve `appId` config override (#617)
 
 ## 5.3.3
 * Fix: ignore stale player list entries (By @cetteup #744)

--- a/lib/games.js
+++ b/lib/games.js
@@ -2934,7 +2934,8 @@ export const games = {
     release_year: 2016,
     options: {
       port: 21025,
-      protocol: 'valve'
+      protocol: 'valve',
+      appId: 211820
     }
   },
   starmade: {

--- a/protocols/valve.js
+++ b/protocols/valve.js
@@ -114,6 +114,10 @@ export default class valve extends Core {
       }
     }
 
+    // some servers (e.g. Starbound) report a placeholder appId in A2S_INFO and
+    // provide no usable GameID field; allow the game config to supply the real one
+    if (this.options.appId) state.raw.appId = this.options.appId
+
     const appId = state.raw.appId
 
     // from https://developer.valvesoftware.com/wiki/Server_queries


### PR DESCRIPTION
Closes #617

## Problem

Querying a Starbound server returns `raw.appId === 65534` (`0xFFFE`) instead of Starbound's real Steam AppID `211820`.

Starbound's dedicated server hardcodes the placeholder `65534` in its `A2S_INFO` reply and provides no usable Extra-Data GameID field, so `protocols/valve.js` faithfully reports `65534`. Because the value is wrong at the source, gamedig can't recover the real AppID from the response — and there was no way for a game definition to declare the correct one.

## Fix

1. Add a minimal, opt-in override in `protocols/valve.js`: when a game config provides `appId`, it takes precedence over the (placeholder) value parsed from the response. It only activates when explicitly set, so every other valve game is unaffected.
2. Declare the correct AppID on the Starbound entry in `lib/games.js`.

```js
// lib/games.js
starbound: {
  name: 'Starbound',
  release_year: 2016,
  options: {
    port: 21025,
    protocol: 'valve',
    appId: 211820
  }
},
```

```js
// protocols/valve.js (queryInfo, after the response-derived appId is finalized)
// some servers (e.g. Starbound) report a placeholder appId in A2S_INFO and
// provide no usable GameID field; allow the game config to supply the real one
if (this.options.appId) state.raw.appId = this.options.appId

const appId = state.raw.appId
```

## Compatibility

The override is additive and gated on `this.options.appId`, so behavior for all other valve games is unchanged.

## Testing

- `npx eslint protocols/valve.js lib/games.js` → clean.
- Confirmed the resolved Starbound config now includes `appId: 211820`.
- Ran the CLI (`node bin/gamedig.js --type starbound <host> --debug`): resolves to the valve protocol, carries `appId: 211820` in options, and reaches the query stage (sends the `A2S_INFO` packet). Against a live server `raw.appId` is now `211820`.