### PR TITLE
fix: remove Red Orchestra and update legacy ids to an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 ## To Be Released...
 ## 5.X.Y
+* Fix: Red Orchestra - merge the bogus `redorchestra` entry into `Red Orchestra: Ostfront 41-45` (`roo4145`) and switch it to the `unreal2` protocol; `redorchestra` is kept as an old id (#616)
 * Feat: American Truck Simulator - Added support (#768)
 * Feat: The Cenozoic Era - Added support (#768)
 * Feat: VEIN - Added support (#768)

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -250,7 +250,6 @@
 | rdkf                 | Rag Doll Kung Fu                                 | [Valve Protocol](#valve)                         |
 | rdr2r                | Red Dead Redemption 2 - RedM                     |                                                  |
 | redline              | Redline                                          |                                                  |
-| redorchestra         | Red Orchestra                                    |                                                  |
 | redorchestra2        | Red Orchestra 2                                  | [Valve Protocol](#valve)                         |
 | renegade10           | Renegade X                                       |                                                  |
 | renown               | Renown                                           | [EOS Protocol](#epic)                            |

--- a/MIGRATE_IDS.md
+++ b/MIGRATE_IDS.md
@@ -116,6 +116,7 @@ This means some ids will not work as they could have been changed to something e
 | r6                   | → | rainbowsix           |
 | r6roguespear         | → | rs2rs                |
 | r6ravenshield        | → | rs3rs                |
+| redorchestra         | → | roo4145              |
 | redorchestraost      | → | roo4145              |
 | redm                 | → | rdr2r                |
 | riseofnations        | → | ron                  |

--- a/lib/game-resolver.js
+++ b/lib/game-resolver.js
@@ -15,7 +15,9 @@ export const lookup = (options) => {
 
   if (options.checkOldIDs) {
     Object.keys(games).forEach((id) => {
-      if (games[id]?.extra?.old_id === type) {
+      const oldId = games[id]?.extra?.old_id
+      const oldIds = Array.isArray(oldId) ? oldId : [oldId]
+      if (oldIds.includes(type)) {
         game = games[id]
       }
     })

--- a/lib/games.js
+++ b/lib/games.js
@@ -2455,25 +2455,16 @@ export const games = {
       protocol: 'gamespy1'
     }
   },
-  redorchestra: {
-    name: 'Red Orchestra',
-    release_year: 2018,
-    options: {
-      port: 7758,
-      port_query_offset: 1,
-      protocol: 'unreal2'
-    }
-  },
   roo4145: {
     name: 'Red Orchestra: Ostfront 41-45',
     release_year: 2006,
     options: {
       port: 7757,
-      port_query_offset: 10,
-      protocol: 'gamespy1'
+      port_query_offset: 1,
+      protocol: 'unreal2'
     },
     extra: {
-      old_id: 'redorchestraost'
+      old_id: ['redorchestraost', 'redorchestra']
     }
   },
   redorchestra2: {

--- a/tools/find_id_duplicates.js
+++ b/tools/find_id_duplicates.js
@@ -5,7 +5,8 @@ const ids = Object.keys(games)
 Object.keys(games).forEach((key) => {
   if (games[key].extra && games[key].extra.old_id) {
     const idOld = games[key].extra.old_id
-    ids.push(idOld)
+    const idsOld = Array.isArray(idOld) ? idOld : [idOld]
+    ids.push(...idsOld)
   }
 })
 


### PR DESCRIPTION
Closes #616

## Problem

`lib/games.js` had two entries for what is the same game:

- `roo4145` — "Red Orchestra: Ostfront 41-45" (2006), `gamespy1`, query offset `+10`
- `redorchestra` — "Red Orchestra" (2018), `unreal2`, query offset `+1`

As reported in #616, there is no standalone game called "Red Orchestra". Maintainer @CosminPerRam confirmed in the thread that the 2018 release year is bogus (no such game exists) and that the `redorchestra` entry "was added as an alternative query method, not necessarily as being another game." His live testing showed `unreal2` with a `+1` offset responded on **both** test servers, while `gamespy1` responded on only one and `valve` on none — i.e. `unreal2`/`+1` (the same family as Killing Floor 1) is the reliable query, not `gamespy1`.

## Fix

- Removed the duplicate `redorchestra` entry.
- Kept `roo4145` as the canonical id (it has the correct full name + release year and was already the `MIGRATE_IDS.md` target for `redorchestraost`), and switched it to the protocol/offset that actually works.
- Preserved **both** legacy ids (`redorchestraost` and `redorchestra`) via `extra.old_id`, which now accepts a string **or an array**.

```js
roo4145: {
  name: 'Red Orchestra: Ostfront 41-45',
  release_year: 2006,
  options: {
    port: 7757,
    port_query_offset: 1,
    protocol: 'unreal2'
  },
  extra: {
    old_id: ['redorchestraost', 'redorchestra']
  }
},
```

Supporting changes for the array `old_id`:

```js
// lib/game-resolver.js
if (options.checkOldIDs) {
  Object.keys(games).forEach((id) => {
    const oldId = games[id]?.extra?.old_id
    const oldIds = Array.isArray(oldId) ? oldId : [oldId]
    if (oldIds.includes(type)) {
      game = games[id]
    }
  })
}

// tools/find_id_duplicates.js
if (games[key].extra && games[key].extra.old_id) {
  const idOld = games[key].extra.old_id
  const idsOld = Array.isArray(idOld) ? idOld : [idOld]
  ids.push(...idsOld)
}
```

Also: added `redorchestra → roo4145` to `MIGRATE_IDS.md`, regenerated `GAMES_LIST.md` via `tools/generate_games_list.js` (drops the `redorchestra` row), and added a `CHANGELOG.md` entry under "To Be Released".

## Examples

```
roo4145                          -> {"port":7757,"port_query_offset":1,"protocol":"unreal2"}
redorchestra                     -> Invalid game: redorchestra        (deprecated; requires checkOldIDs)
redorchestra     (checkOldIDs)   -> {"port":7757,"port_query_offset":1,"protocol":"unreal2"}
redorchestraost  (checkOldIDs)   -> {"port":7757,"port_query_offset":1,"protocol":"unreal2"}
```

## Compatibility

- `roo4145` continues to work; its query is now `unreal2`/`+1` (more reliable across servers per the issue testing).
- `redorchestra` and `redorchestraost` keep working when `checkOldIDs: true` (or `--checkOldIDs`) is passed — the project's standard deprecation path, now documented in `MIGRATE_IDS.md`.
- The `old_id` schema is backwards compatible: existing single-string `old_id` values are untouched; only `roo4145` uses the array form.

> Note: a single game entry only supports one `protocol`, so this picks the reliably-responding `unreal2` method. Supporting `gamespy1` as a fallback for servers that only answer it would need the per-game multi-query feature tracked in #608.

## Testing

- `node tools/find_id_duplicates.js` → "No duplicates found."
- Resolver spot-check (see Examples above) confirms `roo4145` resolves to `unreal2`/`+1`, and both legacy ids resolve only with `checkOldIDs`.
- `npm run lint:check`: the edited files (`lib/games.js`, `lib/game-resolver.js`, `tools/find_id_duplicates.js`) are clean. The other files eslint flags are pre-existing and untouched by this change.
- `tools/run-id-tests.js` requires the external `gamedig-id-tests` binary (not available here), so it was not run; `find_id_duplicates.js` covers the id-collision check locally.