### PR TITLE
feat: add stripTypes option to return plain objects/arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Feat: The Cenozoic Era - Added support (#768)
 * Feat: VEIN - Added support (#768)
 * Feat: Mindustry - Added support (#768)
+* Feat: Add `stripTypes` option to return plain JS objects/arrays instead of the typed `Results`/`Players`/`Player` instances (#657)
 
 ## 5.3.3
 * Fix: ignore stale player list entries (By @cetteup #744)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Note that some games might require additional values to be specified.
 | **stripColors**            | boolean | `true`      | Enables stripping colors for protocols: unreal2, savage2, quake3, nadeo, gamespy2, doom3, armagetron.                                                                                                                         |
 | **portCache**              | boolean | `true`      | After you queried a server, the second time you query that exact server (identified by specified ip and port), first add an attempt to query with the last successful port.                                                   |
 | **noBreadthOrder**         | boolean | `false`     | Enable the behaviour of retrying an attempt X times followed by the next attempt X times, otherwise try attempt A, then B, then A, then B until reaching the X retry count of each.                                           |
+| **stripTypes**             | boolean | `false`     | Return the result as plain JS objects/arrays instead of the typed `Results`/`Players`/`Player` instances. Useful for `JSON.stringify`, `structuredClone`, deep-cloning, comparisons and environments (e.g. Node-RED) that choke on the typed wrappers. |
 | **checkOldIDs**            | boolean | `false`     | Also checks the old ids amongst the current ones.                                                                                                                                                                             |
 
 ## Query Response

--- a/bin/gamedig.js
+++ b/bin/gamedig.js
@@ -6,7 +6,7 @@ import Minimist from 'minimist'
 import { GameDig } from './../lib/index.js'
 
 const argv = Minimist(process.argv.slice(2), {
-  boolean: ['pretty', 'debug', 'givenPortOnly', 'requestRules', 'requestPlayers', 'requestRulesRequired', 'requestPlayersRequired', 'stripColors', 'portCache', 'noBreadthOrder', 'checkOldIDs', 'rejectUnauthorized'],
+  boolean: ['pretty', 'debug', 'givenPortOnly', 'requestRules', 'requestPlayers', 'requestRulesRequired', 'requestPlayersRequired', 'stripColors', 'portCache', 'noBreadthOrder', 'checkOldIDs', 'rejectUnauthorized', 'stripTypes'],
   string: ['guildId', 'serverId', 'listenUdpPort', 'ipFamily', 'token'],
   default: {
     stripColors: true,

--- a/lib/QueryRunner.js
+++ b/lib/QueryRunner.js
@@ -1,6 +1,7 @@
 import { lookup } from './game-resolver.js'
 import { getProtocol } from './ProtocolResolver.js'
 import GlobalUdpSocket from './GlobalUdpSocket.js'
+import { toPlainObject } from './Results.js'
 
 const defaultOptions = {
   socketTimeout: 2000,
@@ -10,7 +11,8 @@ const defaultOptions = {
   portCache: true,
   noBreadthOrder: false,
   ipFamily: 0,
-  requestPlayers: true
+  requestPlayers: true,
+  stripTypes: false
 }
 
 export default class QueryRunner {
@@ -98,7 +100,7 @@ export default class QueryRunner {
         if (attempt.portCache) {
           this.portCache[`${userOptions.address}:${userOptions.port}`] = attempt.port
         }
-        return response
+        return optionsCollection.stripTypes ? toPlainObject(response) : response
       } catch (e) {
         e.stack = 'Attempt #' + attemptNum + ' - Port=' + attempt.port + ' Retry=' + (retry) + ':\n' + e.stack
         errors.push(e)

--- a/lib/Results.js
+++ b/lib/Results.js
@@ -34,3 +34,35 @@ export class Results {
 
   queryPort = 0
 }
+
+/**
+ * Recursively convert a query result into plain JS objects/arrays.
+ *
+ * The typed wrappers (Results, Players, Player) extend Object/Array, which
+ * makes them awkward to JSON serialize, structuredClone, deep-clone or compare.
+ * This strips those prototypes, returning only plain objects and arrays while
+ * leaving primitives and structuredClone-friendly values (Buffer, Date) intact.
+ *
+ * @template T
+ * @param {T} value
+ * @returns {T}
+ */
+export function toPlainObject (value) {
+  if (Array.isArray(value)) {
+    // Array.from() always yields a plain Array, even for subclasses like Players
+    // (whose .map() would otherwise return another Players instance).
+    return Array.from(value, toPlainObject)
+  }
+  if (value !== null && typeof value === 'object') {
+    // Leave already clone-friendly objects untouched rather than flattening them.
+    if (Buffer.isBuffer(value) || value instanceof Date) {
+      return value
+    }
+    const out = {}
+    for (const key of Object.keys(value)) {
+      out[key] = toPlainObject(value[key])
+    }
+    return out
+  }
+  return value
+}


### PR DESCRIPTION
Closes #657

## Problem

`GameDig.query()` resolves to a typed `Results` instance whose `players`/`bots` are `Players` objects (an `Array` subclass) holding `Player` instances. These custom prototypes break common downstream operations:

- `structuredClone(state)` / `Object.assign({}, state)` throw or lose data.
- Node-RED deep-clones messages between nodes and fails with `TypeError: Class constructor Players cannot be invoked without 'new'`.
- Deep-equality comparisons and some serializers treat the wrappers differently from plain data.

Today consumers must hand-roll a conversion (spreading every nested array) before they can use the result.

## Fix

Add an opt-in `stripTypes` option (default `false`, so existing behavior is unchanged). When enabled, the final result is recursively converted to plain objects/arrays before being returned.

A small recursive helper `toPlainObject()` is exported from `lib/Results.js`:

```js
export function toPlainObject (value) {
  if (Array.isArray(value)) {
    // Array.from() always yields a plain Array, even for subclasses like Players
    // (whose .map() would otherwise return another Players instance).
    return Array.from(value, toPlainObject)
  }
  if (value !== null && typeof value === 'object') {
    // Leave already clone-friendly objects untouched rather than flattening them.
    if (Buffer.isBuffer(value) || value instanceof Date) {
      return value
    }
    const out = {}
    for (const key of Object.keys(value)) {
      out[key] = toPlainObject(value[key])
    }
    return out
  }
  return value
}
```

It's applied at the single success-return point in `QueryRunner.run()`:

```js
return optionsCollection.stripTypes ? toPlainObject(response) : response
```

`stripTypes: false` was added to `defaultOptions`, the flag was registered for the CLI (`bin/gamedig.js`), and it was documented in the README options table.

Implementation notes:

- `Results` has no existing `toJSON`, so nothing to reuse — but `Players`/`Player` already serialize fine via `JSON.stringify`. The helper is needed for the non-JSON cases (`structuredClone`, prototype checks, in-place plain data).
- `Array.from()` is used instead of `.map()` because `Players.prototype.map()` returns another `Players` instance (Array species), which would defeat the purpose.
- The conversion is non-mutating (the original typed object is left intact) and preserves `Buffer`/`Date` values, which are already `structuredClone`-friendly.

## Examples

```js
import { GameDig } from 'gamedig'

// Default: typed Results (unchanged behavior)
const typed = await GameDig.query({ type: 'csgo', host: '127.0.0.1' })
typed.players instanceof Array        // true, but it's a `Players` subclass
Object.getPrototypeOf(typed)          // Results.prototype

// Opt-in: plain objects/arrays
const plain = await GameDig.query({ type: 'csgo', host: '127.0.0.1', stripTypes: true })
Object.getPrototypeOf(plain)          // Object.prototype
Object.getPrototypeOf(plain.players)  // Array.prototype
structuredClone(plain)                // works, no throw
```

CLI:

```sh
gamedig --type csgo --stripTypes 127.0.0.1:27015
```

Node-RED (the motivating case) becomes a one-liner — no manual nested spreading:

```js
GameDig.query({ ...options, stripTypes: true }).then((state) => {
  msg.data = state // plain objects/arrays, safe for Node-RED to clone
  node.send(msg)
})
```

## Compatibility

- Fully backwards-compatible: `stripTypes` defaults to `false`, so the default return value remains the typed `Results` instance.
- No changes to the response schema/shape — only the prototypes of the returned objects/arrays change when the flag is enabled.
- New named export `toPlainObject` from `lib/Results.js` (additive).

## Testing

- Built a fixture `Results` object (typed `Players` with `Player` entries plus a nested `raw` object) and asserted, with the option enabled:
  - `Object.getPrototypeOf(result) === Object.prototype` (and the same for `players`, each player, `raw`, and nested objects).
  - `players` is a true `Array` (not a `Players` subclass) and entries are not `Player` instances.
  - `JSON.parse(JSON.stringify(result))` deep-equals the result.
  - `structuredClone(result)` succeeds and deep-equals the result.
  - The original typed object is left unmodified (non-mutating).
  - `Buffer`/`Date` values are preserved rather than flattened.
- All assertions passed.
- `npm run lint:check`: changes introduce 0 new lint errors. Note the repo's `npm run lint:check` already fails on a clean `master` (identical 31 pre-existing errors before and after this change), because `.eslintrc.json` pins `ecmaVersion: 2021` while the codebase uses ES2022 class/private fields — unrelated to this PR.