### PR TITLE
feat(game): add game Chilvary 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## To Be Released...
 ## 5.X.Y
-* Feat: Chivalry 2 - Added support
+* Feat: Chivalry 2 - Added support (By @podrivo #787)
 * Feat: American Truck Simulator - Added support (#768)
 * Feat: The Cenozoic Era - Added support (#768)
 * Feat: VEIN - Added support (#768)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 ## To Be Released...
 ## 5.X.Y
+* Feat: Chivalry 2 - Added support
 * Feat: American Truck Simulator - Added support (#768)
 * Feat: The Cenozoic Era - Added support (#768)
 * Feat: VEIN - Added support (#768)

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -60,7 +60,7 @@
 | cacr                 | Command and Conquer: Renegade                    |                                                  |
 | cbu                  | Clive Barker's Undying                           |                                                  |
 | chaser               | Chaser                                           |                                                  |
-| chivalry2            | Chivalry 2                                       | [Valve Protocol](#valve)                         |
+| chivalry2            | Chivalry 2                                       | [Notes](#chivalry2), [Valve Protocol](#valve)    |
 | chrome               | Chrome                                           |                                                  |
 | cmw                  | Chivalry: Medieval Warfare                       | [Valve Protocol](#valve)                         |
 | cod                  | Call of Duty                                     |                                                  |
@@ -525,6 +525,9 @@ Does not provide players data.
 
 ### <a name="soulmask"></a>Soulmask
 Soulmask reports a hardcoded version (`1.0.0.0`) in the A2S_INFO response. To get the real game version, pass `requestRules: true` — the actual version is read from the `NO_s` rules key.
+
+### <a name="chivalry2"></a>Chivalry 2
+Chivalry 2 reports an incorrect `appId` (`100`) in the `raw` field. This is a limitation of the A2S protocol, so it cannot represent Chivalry 2's real Steam appId (`1824220`).
 
 Protocols with Additional Notes
 ---

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -60,6 +60,7 @@
 | cacr                 | Command and Conquer: Renegade                    |                                                  |
 | cbu                  | Clive Barker's Undying                           |                                                  |
 | chaser               | Chaser                                           |                                                  |
+| chivalry2            | Chivalry 2                                       | [Valve Protocol](#valve)                         |
 | chrome               | Chrome                                           |                                                  |
 | cmw                  | Chivalry: Medieval Warfare                       | [Valve Protocol](#valve)                         |
 | cod                  | Call of Duty                                     |                                                  |

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -529,7 +529,7 @@ Soulmask reports a hardcoded version (`1.0.0.0`) in the A2S_INFO response. To ge
 ### <a name="chivalry2"></a>Chivalry 2
 Chivalry 2 reports an incorrect `appId` (`100`) in the `raw` field. This is a limitation of the A2S protocol, so it cannot represent Chivalry 2's real Steam appId (`1824220`).
 
-Player names containing non-ASCII characters may be truncated by the server, so a name like `SŦĐ Eureka` arrives as `SŦĐ Eure`, while pure-ASCII names come through intact.
+Player names containing non-ASCII characters may be truncated by the server, so a name like `ŦĐ Vanguardian` arrives as `ŦĐ Vanguard`, while pure-ASCII names come through intact.
 
 Protocols with Additional Notes
 ---

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -529,6 +529,8 @@ Soulmask reports a hardcoded version (`1.0.0.0`) in the A2S_INFO response. To ge
 ### <a name="chivalry2"></a>Chivalry 2
 Chivalry 2 reports an incorrect `appId` (`100`) in the `raw` field. This is a limitation of the A2S protocol, so it cannot represent Chivalry 2's real Steam appId (`1824220`).
 
+Player names containing non-ASCII characters may be truncated by the server, so a name like `SŦĐ Eureka` arrives as `SŦĐ Eure`, while pure-ASCII names come through intact.
+
 Protocols with Additional Notes
 ---
 

--- a/lib/games.js
+++ b/lib/games.js
@@ -630,6 +630,9 @@ export const games = {
       port: 7777,
       port_query: 7071,
       protocol: 'valve'
+    },
+    extra: {
+      doc_notes: 'chivalry2'
     }
   },
   cmw: {

--- a/lib/games.js
+++ b/lib/games.js
@@ -623,6 +623,15 @@ export const games = {
       protocol: 'ase'
     }
   },
+  chivalry2: {
+    name: 'Chivalry 2',
+    release_year: 2021,
+    options: {
+      port: 7777,
+      port_query: 7071,
+      protocol: 'valve'
+    }
+  },
   cmw: {
     name: 'Chivalry: Medieval Warfare',
     release_year: 2012,


### PR DESCRIPTION
## Add Chivalry 2

Adds support for **Chivalry 2** as a Valve (A2S) game.

### Changes
- Add `chivalry2` game entry (`valve` protocol, game port `7777`, query port `7071`)
- Add `CHANGELOG.md` entry
- Document Chivalry 2's known server-side quirks in `GAMES_LIST.md`:
  - reports an incorrect `appId` (`100`), a limitation of the 16-bit A2S field that can't hold the real appId (`1824220`)
  - truncates player names containing non-ASCII characters (e.g. `SŦĐ Eureka` → `SŦĐ Eure`)

Closes #780

### Example

<details>
<summary><code>gamedig --type chivalry2 --pretty XX.XXX.XXX.XX:XXXXX</code></summary>

```json
{
  "name": "[NA 64] Tempest Realm TO | Casual Nights | discord.gg/tempest",
  "map": "TO_RudhelmSiege",
  "password": false,
  "raw": {
    "protocol": 85,
    "folder": "TO",
    "game": "Chivalry 2",
    "appId": 100,
    "numbots": 0,
    "listentype": "D",
    "environment": "L",
    "secure": 1,
    "players": [
      { "name": "ironhalbert", "score": 0, "time": 1487.553955078125 },
      { "name": "GallowGrin", "score": 0, "time": 1322.094482421875 },
      { "name": "ŦĐ Vanguard", "score": 0, "time": 1190.741210937500 },
      { "name": "δσχ reaper", "score": 0, "time": 998.328125000000 },
      { "name": "ØscarMike", "score": 0, "time": 742.661376953125 },
      { "name": "DK - mason-7741", "score": 0, "time": 503.927734375000 },
      { "name": "Brynjar", "score": 0, "time": 311.204864501953 },
      { "name": "kettle_knight", "score": 0, "time": 87.442192077637 }
    ]
  },
  "version": "261891",
  "maxplayers": 64,
  "numplayers": 58,
  "queryPort": XXXXX,
  "connect": "XX.XXX.XXX.XX:XXXXX",
  "ping": 142
}
```

> Player list trimmed for brevity.

</details>