### PR TITLE
fix(game/asa): add CDN lookup and --token query option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 5.X.Y
 * Fix: ignore stale player list entries (By @cetteup #744)
 * Feat: Plutonium - Added support (#745)
+* Fix: ASA - resolve servers via ARK CDN lists, with a `token` option for private servers
+* Docs: ASA - document the EOS session id / `token` workaround and its limitations
 
 ## 5.3.2
 * Fix: detect BFBC2 Vietnam DLC as BFBC2 (By @cetteup #713)

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -23,7 +23,7 @@
 | armagetronadvanced   | Armagetron Advanced                              |                                                  |
 | armareforger         | ARMA: Reforger                                   | [Notes](#armareforger), [Valve Protocol](#valve) |
 | armaresistance       | ARMA: Resistance                                 |                                                  |
-| asa                  | Ark: Survival Ascended                           | [EOS Protocol](#epic)                            |
+| asa                  | Ark: Survival Ascended                           | [Notes](#asa), [EOS Protocol](#epic)             |
 | ase                  | Ark: Survival Evolved                            | [Valve Protocol](#valve)                         |
 | asr08                | Arca Sim Racing '08                              |                                                  |
 | assettocorsa         | Assetto Corsa                                    |                                                  |
@@ -527,6 +527,20 @@ option: `requestRules: true`. Beware that this may increase query time.
 
 ### <a name="epic"></a>Epic Online Services (EOS) Protocol
 EOS does not provide players data.
+
+### <a name="asa"></a>Ark: Survival Ascended
+ASA does not answer direct server queries; all server info comes from Epic Online Services (EOS).
+
+The `asa` protocol resolves the server's EOS **session ID** and then reads that session directly:
+
+- **Official and Nitrado-hosted unofficial servers** are listed on ARK's public server lists, so they are resolved automatically from `IP:port` (no extra options needed). Because these lists are large, you may need to raise the timeout, e.g. `socketTimeout: 10000`.
+- **Private / self-hosted servers** are not on those public lists and cannot be discovered by IP. For these, pass the server's EOS session ID via the `token` option.
+
+The session ID is a 32-character hex string (e.g. `1b3a5edf9b1f4e7b82affa72496ea46d`) that the server logs when it registers with EOS (check `ShooterGame/Saved/Logs/`). Note that the session ID changes every time the server restarts, so it must be refreshed after each restart.
+
+```
+gamedig --type asa --token <eos-session-id> 1.2.3.4:7777
+```
 
 ### <a name="palworld"></a>Palworld
 Palworld support can be unstable, the devs mention the api is currently experimental.  

--- a/lib/games.js
+++ b/lib/games.js
@@ -79,6 +79,9 @@ export const games = {
     options: {
       port: 7777,
       protocol: 'asa'
+    },
+    extra: {
+      doc_notes: 'asa'
     }
   },
   assettocorsa: {

--- a/protocols/asa.js
+++ b/protocols/asa.js
@@ -9,10 +9,66 @@ export default class asa extends Epic {
     this.clientSecret = 'PP5UGxysEieNfSrEicaD1N2Bb3TdXuD7xHYcsdUHZ7s'
     this.deploymentId = 'ad9a8feffb3b4b2ca315546f038c3ae2'
     this.wildcardMatchmaking = true
+
+    this.cdnLists = [
+      'https://cdn2.arkdedicated.com/servers/asa/officialserverlist.json',
+      'https://cdn2.arkdedicated.com/servers/asa/unofficialserverlist.json'
+    ]
   }
 
   async run (state) {
     await super.run(state)
     state.version = state.raw.attributes.BUILDID_s + '.' + state.raw.attributes.MINORBUILDID_s
+  }
+
+  async queryInfo (state) {
+    const sessionId = await this.findSessionId()
+    const session = await this.getSessionById(sessionId)
+
+    state.name = session.attributes.CUSTOMSERVERNAME_s
+    state.map = session.attributes.MAPNAME_s
+    state.password = session.attributes.SERVERPASSWORD_b
+    state.numplayers = session.totalPlayers
+    state.maxplayers = session.settings.maxPublicPlayers
+
+    for (const player of session.publicPlayers) {
+      state.players.push({ name: player.name, raw: player })
+    }
+
+    state.raw = session
+  }
+
+  async findSessionId () {
+    if (this.options.token) {
+      this.logger.debug(`Using provided session ID: ${this.options.token}`)
+      return this.options.token
+    }
+
+    for (const url of this.cdnLists) {
+      this.logger.debug(`Fetching server list: ${url}`)
+      const servers = await this.request({ url, responseType: 'json' })
+
+      const match = servers.find(s =>
+        s.IP === this.options.address && s.Port === this.options.port
+      )
+      if (match) {
+        this.logger.debug(`Found session ID: ${match.SessionID}`)
+        return match.SessionID
+      }
+    }
+
+    throw new Error('Server not found in ARK CDN server lists. For private servers, provide the EOS "session ID" via --token.')
+  }
+
+  async getSessionById (sessionId) {
+    const url = `${this.epicApi}/wildcard/matchmaking/v1/${this.deploymentId}/sessions/${sessionId}`
+    const headers = {
+      Authorization: `Bearer ${this.accessToken}`,
+      Accept: 'application/json'
+    }
+
+    this.logger.debug(`GET: ${url}`)
+    const response = await this.request({ url, headers, responseType: 'json' })
+    return response.publicData
   }
 }


### PR DESCRIPTION
Closes https://github.com/gamedig/node-gamedig/issues/762

## Problem

Ark: Survival Ascended (`asa`) servers don't answer direct queries — all server info lives in Epic Online Services (EOS). The current `asa` protocol relies on EOS wildcard matchmaking, but in practice it fails to resolve most servers from just `IP:port`, so querying by address returns nothing for the common cases (official, Nitrado-hosted, and private/self-hosted servers).

There was also no way to query a **private / self-hosted** server at all, since these aren't discoverable through EOS matchmaking by IP.

## Fix

Resolve the server's EOS **session ID** first, then read that session directly:

1. **Public servers** (official + Nitrado unofficial) are resolved automatically by matching `IP:port` against ARK's public CDN server lists.
2. **Private / self-hosted servers** can be queried by passing the EOS session ID via a new `token` option.

```js
// protocols/asa.js
this.cdnLists = [
  'https://cdn2.arkdedicated.com/servers/asa/officialserverlist.json',
  'https://cdn2.arkdedicated.com/servers/asa/unofficialserverlist.json'
]

async findSessionId () {
  if (this.options.token) {
    this.logger.debug(`Using provided session ID: ${this.options.token}`)
    return this.options.token
  }

  for (const url of this.cdnLists) {
    const servers = await this.request({ url, responseType: 'json' })
    const match = servers.find(s =>
      s.IP === this.options.address && s.Port === this.options.port
    )
    if (match) return match.SessionID
  }

  throw new Error('Server not found in ARK CDN server lists. For private servers, provide the EOS "session ID" via --token.')
}
```

The resolved session ID is then read via the EOS wildcard matchmaking sessions endpoint (`getSessionById`) and mapped into the standard fields (`name`, `map`, `password`, `numplayers`, `maxplayers`, `players`), with the full session kept on `raw`.

Supporting changes:
- Added `extra.doc_notes: 'asa'` to the `asa` entry in `lib/games.js` so `GAMES_LIST.md` links to the new notes.
- Documented the EOS session ID / `token` workaround and its limitations in `GAMES_LIST.md`.
- Added a `CHANGELOG.md` entry under "To Be Released".

## Examples

```sh
# Public servers (official / Nitrado): resolved automatically by IP:port.
# These lists are large, so raise the timeout if needed.
gamedig --type asa --socketTimeout 10000 1.2.3.4:7777

# Private / self-hosted servers: pass the EOS session ID.
gamedig --type asa --token 1b3a5edf9b1f4e7b82affa72496ea46d 1.2.3.4:7777
```

> The session ID is a 32-character hex string the server logs when it registers with EOS (see `ShooterGame/Saved/Logs/`). It changes on every server restart, so it must be refreshed after each restart.

## Compatibility

- Additive: the `token` option only kicks in when explicitly provided; without it the protocol falls back to the CDN-based IP:port lookup.
- No response-schema changes — the same standard fields are populated, with the raw EOS session retained on `raw`.

## Testing

- Verified public official/unofficial servers resolve from `IP:port` via the CDN lists (raising `socketTimeout` for the large lists).
- Verified a private server resolves when its session ID is passed via `--token`, and that an unknown address throws the documented "provide the EOS session ID via --token" error.
- `npm run lint:check`: no new errors introduced.