### PR TITLE
feat: add StarRupture (#748)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 ## To Be Released...
 ## 5.X.Y
+* Feat: StarRupture - Added support (#748)
 * Feat: American Truck Simulator - Added support (#768)
 * Feat: The Cenozoic Era - Added support (#768)
 * Feat: VEIN - Added support (#768)

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -289,6 +289,7 @@
 | stalker              | S.T.A.L.K.E.R.                                   |                                                  |
 | starbound            | Starbound                                        | [Valve Protocol](#valve)                         |
 | starmade             | StarMade                                         |                                                  |
+| starrupture          | StarRupture                                      |                                                  |
 | starsiege            | Starsiege                                        |                                                  |
 | stbc                 | Star Trek: Bridge Commander                      |                                                  |
 | stn                  | Survive the Nights                               | [Valve Protocol](#valve)                         |

--- a/lib/games.js
+++ b/lib/games.js
@@ -2953,6 +2953,18 @@ export const games = {
       protocol: 'starsiege'
     }
   },
+  starrupture: {
+    name: 'StarRupture',
+    release_year: 2024,
+    options: {
+      port: 7777,
+      protocol: 'starrupture'
+    },
+    extra: {
+      steamAppId: 1631270,
+      serverAppId: 3809400
+    }
+  },
   suicidesurvival: {
     name: 'Suicide Survival',
     release_year: 2008,

--- a/protocols/starrupture.js
+++ b/protocols/starrupture.js
@@ -1,0 +1,12 @@
+import Epic from './epic.js'
+
+export default class starrupture extends Epic {
+  constructor () {
+    super()
+
+    this.clientId = 'xyza7891QS9SjLJfKrqidE9BN6CXodo5'
+    this.clientSecret = 'Zc7H97tXVdGRY05AP8YmUPljS+w+M0n2U3Rp08F7B+U'
+    this.deploymentId = '461bc5e81a1b47bfa93de43fb59a2e23'
+    this.wildcardMatchmaking = true
+  }
+}


### PR DESCRIPTION
**Describe the changes**
- [x] I have added a line in the [CHANGELOG.md](https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md) file.

Adds support for:
* **StarRupture** utilizing the Epic Online Services (EOS) protocol.

**Screenshots or Data**
N/A

**Additional context**
Closes #748