### PR TITLE
feat: add support for Windrose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 ## To Be Released...
 ## 5.X.Y
+* Feat: Windrose - Added support (#791)
 * Feat: American Truck Simulator - Added support (#768)
 * Feat: The Cenozoic Era - Added support (#768)
 * Feat: VEIN - Added support (#768)

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -357,6 +357,7 @@
 | warfork              | Warfork                                          |                                                  |
 | warsow               | Warsow                                           |                                                  |
 | wet                  | Wolfenstein: Enemy Territory                     |                                                  |
+| windrose             | Windrose                                         | [Valve Protocol](#valve)                         |
 | wolfenstein          | Wolfenstein                                      |                                                  |
 | wop                  | World Of Padman                                  |                                                  |
 | wot                  | Wheel of Time                                    |                                                  |

--- a/lib/games.js
+++ b/lib/games.js
@@ -3471,6 +3471,15 @@ export const games = {
       old_id: 'wurm'
     }
   },
+  windrose: {
+    name: 'Windrose',
+    release_year: 2024,
+    options: {
+      port: 7777,
+      port_query_offset: 1,
+      protocol: 'valve'
+    }
+  },
   xonotic: {
     name: 'Xonotic',
     release_year: 2011,


### PR DESCRIPTION
**Describe the changes**
- [x] I have added a line in the [CHANGELOG.md](https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md) file.

Added support for the Windrose dedicated server.
- Added `windrose` to `lib/games.js` utilizing the `valve` protocol on `port_query_offset: 1`.
- Regenerated `GAMES_LIST.md`.
- Updated `CHANGELOG.md` with the new feature.

**Additional context**
Closes #770
