### PR TITLE
feat(games): add s&box support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Feat: The Cenozoic Era - Added support (#768)
 * Feat: VEIN - Added support (#768)
 * Feat: Mindustry - Added support (#768)
+* Feat: s&box - Added support
 
 ## 5.3.3
 * Fix: ignore stale player list entries (By @cetteup #744)

--- a/GAMES_LIST.md
+++ b/GAMES_LIST.md
@@ -269,6 +269,7 @@
 | rust                 | Rust                                             | [Valve Protocol](#valve)                         |
 | s2ats                | Savage 2: A Tortured Soul                        |                                                  |
 | satisfactory         | Satisfactory                                     | [Notes](#satisfactory)                           |
+| sbox                 | s&box                                            | [Valve Protocol](#valve)                         |
 | sdtd                 | 7 Days to Die                                    | [Notes](#sdtd), [Valve Protocol](#valve)         |
 | serioussam           | Serious Sam                                      |                                                  |
 | serioussam2          | Serious Sam 2                                    |                                                  |

--- a/lib/games.js
+++ b/lib/games.js
@@ -2641,6 +2641,15 @@ export const games = {
       old_id: 'savage2'
     }
   },
+  sbox: {
+    name: 's&box',
+    release_year: 2026,
+    options: {
+      port: 27015,
+      port_query: 27016,
+      protocol: 'valve'
+    }
+  },
   sdtd: {
     name: '7 Days to Die',
     release_year: 2013,


### PR DESCRIPTION
Register s&box (id: sbox) using the existing Valve protocol. Query port is independent of the game port (defaults 27016 / 27015).